### PR TITLE
fix: correct Lesson 8 src links in aij 2026-01 config files

### DIFF
--- a/src/en/aij/2026-01-bg/audio.yml
+++ b/src/en/aij/2026-01-bg/audio.yml
@@ -30,7 +30,7 @@ audio:
         target: en/aij/2026-01-bg/01
         title: 7. God Made the Earth
       - src: >-
-          https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-09.mp3
+          https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-08.mp3
         target: en/aij/2026-01-bg/01
         title: 8. God Made the Fish of the Sea
       - src: >-
@@ -82,7 +82,7 @@ audio:
         target: en/aij/2026-01-bg/02
         title: 7. God Made the Earth
       - src: >-
-          https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-09.mp3
+          https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-08.mp3
         target: en/aij/2026-01-bg/02
         title: 8. God Made the Fish of the Sea
       - src: >-
@@ -134,7 +134,7 @@ audio:
         target: en/aij/2026-01-bg/03
         title: 7. God Made the Earth
       - src: >-
-          https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-09.mp3
+          https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-08.mp3
         target: en/aij/2026-01-bg/03
         title: 8. God Made the Fish of the Sea
       - src: >-
@@ -186,7 +186,7 @@ audio:
         target: en/aij/2026-01-bg/04
         title: 7. God Made the Earth
       - src: >-
-          https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-09.mp3
+          https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-08.mp3
         target: en/aij/2026-01-bg/04
         title: 8. God Made the Fish of the Sea
       - src: >-
@@ -238,7 +238,7 @@ audio:
         target: en/aij/2026-01-bg/05
         title: 7. God Made the Earth
       - src: >-
-          https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-09.mp3
+          https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-08.mp3
         target: en/aij/2026-01-bg/05
         title: 8. God Made the Fish of the Sea
       - src: >-
@@ -290,7 +290,7 @@ audio:
         target: en/aij/2026-01-bg/06
         title: 7. God Made the Earth
       - src: >-
-          https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-09.mp3
+          https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-08.mp3
         target: en/aij/2026-01-bg/06
         title: 8. God Made the Fish of the Sea
       - src: >-
@@ -342,7 +342,7 @@ audio:
         target: en/aij/2026-01-bg/07
         title: 6. God Made the Sun, Moon, and Stars
       - src: >-
-          https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-09.mp3
+          https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-08.mp3
         target: en/aij/2026-01-bg/07
         title: 8. God Made the Fish of the Sea
       - src: >-
@@ -366,7 +366,7 @@ audio:
         target: en/aij/2026-01-bg/07
         title: 13. God Made the Sabbath
       - src: >-
-          https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-09.mp3
+          https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-08.mp3
         target: en/aij/2026-01-bg/08
         title: 8. God Made the Fish of the Sea
       - src: >-
@@ -450,7 +450,7 @@ audio:
         target: en/aij/2026-01-bg/09
         title: 7. God Made the Earth
       - src: >-
-          https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-09.mp3
+          https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-08.mp3
         target: en/aij/2026-01-bg/09
         title: 8. God Made the Fish of the Sea
       - src: >-
@@ -502,7 +502,7 @@ audio:
         target: en/aij/2026-01-bg/10
         title: 7. God Made the Earth
       - src: >-
-          https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-09.mp3
+          https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-08.mp3
         target: en/aij/2026-01-bg/10
         title: 8. God Made the Fish of the Sea
       - src: >-
@@ -554,7 +554,7 @@ audio:
         target: en/aij/2026-01-bg/11
         title: 7. God Made the Earth
       - src: >-
-          https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-09.mp3
+          https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-08.mp3
         target: en/aij/2026-01-bg/11
         title: 8. God Made the Fish of the Sea
       - src: >-
@@ -606,7 +606,7 @@ audio:
         target: en/aij/2026-01-bg/12
         title: 7. God Made the Earth
       - src: >-
-          https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-09.mp3
+          https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-08.mp3
         target: en/aij/2026-01-bg/12
         title: 8. God Made the Fish of the Sea
       - src: >-
@@ -658,7 +658,7 @@ audio:
         target: en/aij/2026-01-bg/13
         title: 7. God Made the Earth
       - src: >-
-          https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-09.mp3
+          https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-08.mp3
         target: en/aij/2026-01-bg/13
         title: 8. God Made the Fish of the Sea
       - src: >-

--- a/src/en/aij/2026-01-kd/audio.yml
+++ b/src/en/aij/2026-01-kd/audio.yml
@@ -30,7 +30,7 @@ audio:
         target: en/aij/2026-01-kd/01
         title: 7. Noah Builds an Ark
       - src: >-
-          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-kd/assets/KD-09.mp3
+          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-kd/assets/KD-08.mp3
         target: en/aij/2026-01-kd/01
         title: 8. A Rainbow Promise
       - src: >-
@@ -82,7 +82,7 @@ audio:
         target: en/aij/2026-01-kd/02
         title: 7. Noah Builds an Ark
       - src: >-
-          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-kd/assets/KD-09.mp3
+          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-kd/assets/KD-08.mp3
         target: en/aij/2026-01-kd/02
         title: 8. A Rainbow Promise
       - src: >-
@@ -134,7 +134,7 @@ audio:
         target: en/aij/2026-01-kd/03
         title: 7. Noah Builds an Ark
       - src: >-
-          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-kd/assets/KD-09.mp3
+          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-kd/assets/KD-08.mp3
         target: en/aij/2026-01-kd/03
         title: 8. A Rainbow Promise
       - src: >-
@@ -186,7 +186,7 @@ audio:
         target: en/aij/2026-01-kd/04
         title: 7. Noah Builds an Ark
       - src: >-
-          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-kd/assets/KD-09.mp3
+          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-kd/assets/KD-08.mp3
         target: en/aij/2026-01-kd/04
         title: 8. A Rainbow Promise
       - src: >-
@@ -238,7 +238,7 @@ audio:
         target: en/aij/2026-01-kd/05
         title: 7. Noah Builds an Ark
       - src: >-
-          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-kd/assets/KD-09.mp3
+          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-kd/assets/KD-08.mp3
         target: en/aij/2026-01-kd/05
         title: 8. A Rainbow Promise
       - src: >-
@@ -290,7 +290,7 @@ audio:
         target: en/aij/2026-01-kd/06
         title: 7. Noah Builds an Ark
       - src: >-
-          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-kd/assets/KD-09.mp3
+          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-kd/assets/KD-08.mp3
         target: en/aij/2026-01-kd/06
         title: 8. A Rainbow Promise
       - src: >-
@@ -342,7 +342,7 @@ audio:
         target: en/aij/2026-01-kd/07
         title: 6. Cain and Abel
       - src: >-
-          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-kd/assets/KD-09.mp3
+          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-kd/assets/KD-08.mp3
         target: en/aij/2026-01-kd/07
         title: 8. A Rainbow Promise
       - src: >-
@@ -366,7 +366,7 @@ audio:
         target: en/aij/2026-01-kd/07
         title: 13. Baby Isaac
       - src: >-
-          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-kd/assets/KD-09.mp3
+          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-kd/assets/KD-08.mp3
         target: en/aij/2026-01-kd/08
         title: 8. A Rainbow Promise
       - src: >-
@@ -450,7 +450,7 @@ audio:
         target: en/aij/2026-01-kd/09
         title: 7. Noah Builds an Ark
       - src: >-
-          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-kd/assets/KD-09.mp3
+          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-kd/assets/KD-08.mp3
         target: en/aij/2026-01-kd/09
         title: 8. A Rainbow Promise
       - src: >-
@@ -502,7 +502,7 @@ audio:
         target: en/aij/2026-01-kd/10
         title: 7. Noah Builds an Ark
       - src: >-
-          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-kd/assets/KD-09.mp3
+          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-kd/assets/KD-08.mp3
         target: en/aij/2026-01-kd/10
         title: 8. A Rainbow Promise
       - src: >-
@@ -554,7 +554,7 @@ audio:
         target: en/aij/2026-01-kd/11
         title: 7. Noah Builds an Ark
       - src: >-
-          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-kd/assets/KD-09.mp3
+          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-kd/assets/KD-08.mp3
         target: en/aij/2026-01-kd/11
         title: 8. A Rainbow Promise
       - src: >-
@@ -606,7 +606,7 @@ audio:
         target: en/aij/2026-01-kd/12
         title: 7. Noah Builds an Ark
       - src: >-
-          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-kd/assets/KD-09.mp3
+          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-kd/assets/KD-08.mp3
         target: en/aij/2026-01-kd/12
         title: 8. A Rainbow Promise
       - src: >-
@@ -658,7 +658,7 @@ audio:
         target: en/aij/2026-01-kd/13
         title: 7. Noah Builds an Ark
       - src: >-
-          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-kd/assets/KD-09.mp3
+          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-kd/assets/KD-08.mp3
         target: en/aij/2026-01-kd/13
         title: 8. A Rainbow Promise
       - src: >-

--- a/src/en/aij/2026-01-pr/audio.yml
+++ b/src/en/aij/2026-01-pr/audio.yml
@@ -30,7 +30,7 @@ audio:
         target: en/aij/2026-01-pr/01
         title: 7. Noah Builds an Ark
       - src: >-
-          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-pr/assets/PR-09.mp3
+          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-pr/assets/PR-08.mp3
         target: en/aij/2026-01-pr/01
         title: 8. The Rainbow Promise
       - src: >-
@@ -82,7 +82,7 @@ audio:
         target: en/aij/2026-01-pr/02
         title: 7. Noah Builds an Ark
       - src: >-
-          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-pr/assets/PR-09.mp3
+          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-pr/assets/PR-08.mp3
         target: en/aij/2026-01-pr/02
         title: 8. The Rainbow Promise
       - src: >-
@@ -134,7 +134,7 @@ audio:
         target: en/aij/2026-01-pr/03
         title: 7. Noah Builds an Ark
       - src: >-
-          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-pr/assets/PR-09.mp3
+          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-pr/assets/PR-08.mp3
         target: en/aij/2026-01-pr/03
         title: 8. The Rainbow Promise
       - src: >-
@@ -186,7 +186,7 @@ audio:
         target: en/aij/2026-01-pr/04
         title: 7. Noah Builds an Ark
       - src: >-
-          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-pr/assets/PR-09.mp3
+          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-pr/assets/PR-08.mp3
         target: en/aij/2026-01-pr/04
         title: 8. The Rainbow Promise
       - src: >-
@@ -238,7 +238,7 @@ audio:
         target: en/aij/2026-01-pr/05
         title: 7. Noah Builds an Ark
       - src: >-
-          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-pr/assets/PR-09.mp3
+          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-pr/assets/PR-08.mp3
         target: en/aij/2026-01-pr/05
         title: 8. The Rainbow Promise
       - src: >-
@@ -290,7 +290,7 @@ audio:
         target: en/aij/2026-01-pr/06
         title: 7. Noah Builds an Ark
       - src: >-
-          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-pr/assets/PR-09.mp3
+          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-pr/assets/PR-08.mp3
         target: en/aij/2026-01-pr/06
         title: 8. The Rainbow Promise
       - src: >-
@@ -342,7 +342,7 @@ audio:
         target: en/aij/2026-01-pr/07
         title: 6. Cain and Abel
       - src: >-
-          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-pr/assets/PR-09.mp3
+          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-pr/assets/PR-08.mp3
         target: en/aij/2026-01-pr/07
         title: 8. The Rainbow Promise
       - src: >-
@@ -366,7 +366,7 @@ audio:
         target: en/aij/2026-01-pr/07
         title: 13. The Promised Baby
       - src: >-
-          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-pr/assets/PR-09.mp3
+          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-pr/assets/PR-08.mp3
         target: en/aij/2026-01-pr/08
         title: 8. The Rainbow Promise
       - src: >-
@@ -450,7 +450,7 @@ audio:
         target: en/aij/2026-01-pr/09
         title: 7. Noah Builds an Ark
       - src: >-
-          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-pr/assets/PR-09.mp3
+          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-pr/assets/PR-08.mp3
         target: en/aij/2026-01-pr/09
         title: 8. The Rainbow Promise
       - src: >-
@@ -502,7 +502,7 @@ audio:
         target: en/aij/2026-01-pr/10
         title: 7. Noah Builds an Ark
       - src: >-
-          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-pr/assets/PR-09.mp3
+          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-pr/assets/PR-08.mp3
         target: en/aij/2026-01-pr/10
         title: 8. The Rainbow Promise
       - src: >-
@@ -554,7 +554,7 @@ audio:
         target: en/aij/2026-01-pr/11
         title: 7. Noah Builds an Ark
       - src: >-
-          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-pr/assets/PR-09.mp3
+          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-pr/assets/PR-08.mp3
         target: en/aij/2026-01-pr/11
         title: 8. The Rainbow Promise
       - src: >-
@@ -606,7 +606,7 @@ audio:
         target: en/aij/2026-01-pr/12
         title: 7. Noah Builds an Ark
       - src: >-
-          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-pr/assets/PR-09.mp3
+          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-pr/assets/PR-08.mp3
         target: en/aij/2026-01-pr/12
         title: 8. The Rainbow Promise
       - src: >-
@@ -658,7 +658,7 @@ audio:
         target: en/aij/2026-01-pr/13
         title: 7. Noah Builds an Ark
       - src: >-
-          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-pr/assets/PR-09.mp3
+          https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-pr/assets/PR-08.mp3
         target: en/aij/2026-01-pr/13
         title: 8. The Rainbow Promise
       - src: >-


### PR DESCRIPTION
## Description
Fixes a copy-paste error where Lesson 8 mistakenly pointed to the Lesson 9 track URL in:
- `src/en/aij/2026-01-kd/audio.yml`
- `src/en/aij/2026-01-pr/audio.yml`
- `src/en/aij/2026-01-bg/audio.yml`

This resulted in the audio for Lesson 9 playing during Lesson 8. 