### PR TITLE
feat: AIJ Beginner Q1 2026 — Vivos em Jesus (PT-BR)

### DIFF
--- a/src/pt/aij/2026-01-bg/00-introduction/info.yml
+++ b/src/pt/aij/2026-01-bg/00-introduction/info.yml
@@ -1,0 +1,1 @@
+title: Introdução

--- a/src/pt/aij/2026-01-bg/00-introduction/introduction.md
+++ b/src/pt/aij/2026-01-bg/00-introduction/introduction.md
@@ -1,0 +1,19 @@
+---
+title: Introdução
+markdownTitle: '^[Queridos Pais,]({"style": {\"text\": {\"color\": \"#f4793b\", \"typeface\": \"Omnes-BoldItalic\"}}})'
+background: https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/00-introduction/intro-background.png
+---
+
+Deus confiou sua preciosa criança à sua família como um empréstimo. Dizem que os dias da parentalidade podem parecer longos, mas os anos são curtos. De fato, a rotina diária de cuidar da casa, conciliar trabalho e necessidades da família às vezes pode parecer interminável e cansativa. E, no entanto, os anos passam tão rápido...
+
+Nesta publicação você encontrará histórias e atividades cuidadosamente selecionadas e apropriadas para a idade, para ajudar a guiar seu filho a conhecer e amar Jesus. **Todos os dias, leia a história simples da semana** e convide a **participação do seu filho** enquanto faz isso. As instruções entre parênteses ao longo da narrativa servirão como seu guia durante a leitura. Aponte para as imagens (ou convide seu filho a fazer isso) enquanto lê. Transforme esse momento de aprendizado em uma rotina diária muito especial. As **Atividades para Fazer Durante o Dia** são ideias que você pode realizar com seu filho para reforçar as mensagens da história bíblica. Transforme essas atividades em memórias que se entrelacem em suas vidas para fortalecer as mensagens bíblicas. Reserve um tempo para ler a mensagem espiritual **O Coração da Questão**, escrita especialmente para você. Diga o **versículo para memorizar** ao seu filho todos os dias, mesmo que ele ainda esteja aprendendo a falar. Coloque o cartão do versículo em um local destacado em sua casa para lembrá-lo de fazer isso e mostre-o ao seu filho.
+
+Aceite o desafio de "conduzi-los a Jesus Cristo dia após dia, amorosamente, ternamente, sincera-mente. Você não deve permitir que nada se coloque entre você e esta grande obra" (Ellen G. White, ^[Orientação da Criança]({"style": {\"text\": {\"typeface\": \"Omnes-Italic\"}}}), p. 41).
+
+Muitas vezes, são as pequenas rotinas diárias, em vez dos grandes momentos de nossas vidas, que moldam nosso caráter.
+
+Nesta estação tão agitada, que Deus o renove, o sustente e lhe dê paciência e constância enquanto você ensina seu filho a amar e seguir Jesus, acima de tudo.
+
+{"style": {\"text\": {\"color\": \"#f4793b\", \"typeface\": \"Omnes-BoldItalic\", \"size\": \"sm\"}}}
+Nina e a Equipe da Conferência Geral\
+Escola Sabatina e Ministério Pessoal

--- a/src/pt/aij/2026-01-bg/00-little-devotions/info.yml
+++ b/src/pt/aij/2026-01-bg/00-little-devotions/info.yml
@@ -1,0 +1,3 @@
+title: Pequenas Devoções
+cover: >-
+  https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/00-little-devotions/cover.png

--- a/src/pt/aij/2026-01-bg/00-little-devotions/little-devotions.md
+++ b/src/pt/aij/2026-01-bg/00-little-devotions/little-devotions.md
@@ -1,0 +1,21 @@
+---
+title: Pequenas Devoções
+titleBelowCover: true
+style:
+  segment:
+    title:
+      text:
+        typeface: Omnes-BlackItalic
+        align: center
+        color: "#58b0e3"
+---
+
+Uma das habilidades mais importantes que você pode ensinar ao seu filho é buscar a Deus todos os dias em devoção pessoal. Embora seu filho tenha agora apenas 1, 2 ou 3 anos de idade, não é cedo demais para começar a ensiná-lo a fazer isso de maneiras simples.
+
+**Como posso começar a ensinar meu filho Iniciante a voltar seu coração para Jesus?**
+
+1. **ORE**: Todos os dias, ore para que o coração do seu filho se abra para Jesus.
+2. **NOS MOMENTOS DO DIA A DIA**: Procure oportunidades para falar sobre Jesus e o quanto você O ama. Cante músicas simples sobre isso e ensine seu filho a cantar com você. Louvor espontâneo e autêntico nesta idade é uma parte importante da construção da fé.
+3. **SEU LUGAR DE DEVOCIONAL**: Escolha uma cadeira, peitoril de janela ou lugar habitual onde você lerá diariamente sua Bíblia e orará. Faça isso em uma parte visível da sua casa, como a sala de estar, para que seu filho veja você passando tempo com Jesus.
+4. **O LUGAR DE DEVOCIONAL DO SEU FILHO**: Não muito longe do seu espaço de estudo bíblico, crie um lugar para seu filho passar tempo com Jesus. Estenda uma pequena toalha ou tapete no chão, junto com alguns livros ilustrados simples da Bíblia (remova brinquedos e outras distrações). Certifique-se de que seu filho não esteja cansado ou com fome durante esse período, para que seja um momento agradável que ele aguarde com expectativa.
+5. **TEMPO COM JESUS**: Explique ao seu filho que todos os dias, neste mesmo horário, vocês dois vão passar um tempo com Jesus. Este será um momento de silêncio, durante o qual vocês lerão, orarão ou cantarão para Jesus. Mostre ao seu filho como ele pode olhar as imagens dos livros bíblicos e pensar nas histórias. Explique que quando Mamãe/Papai passam tempo com Jesus, seu filho também passará tempo com Jesus. Vocês não conversarão nem lerão histórias juntos durante esse tempo, embora possam fazer isso depois! Para começar, passe de dois a cinco minutos de tempo individual, dependendo da capacidade da criança de ficar sentada e concentrada. Aumente gradualmente o tempo conforme seu filho cresça.

--- a/src/pt/aij/2026-01-bg/00-music-and-podcasts/00-music-podcasts.md
+++ b/src/pt/aij/2026-01-bg/00-music-and-podcasts/00-music-podcasts.md
@@ -1,0 +1,59 @@
+---
+title: Música e Podcasts
+---
+
+### Canção Bíblica
+
+!a[https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg-tg/assets/2025-01-bg-scripture-song.mp3] "Gênesis 1:1" {"credits":[{"key":"Compositora","value":"Rosie Smith"},{"key":"Cantores","value":"Yelena and Noah Jovinov"},{"key":"Pianista","value":"Johanna McKay"}],"title": "Créditos","copyright":"Copyright © 2024 Conferência Geral® dos Adventistas do Sétimo Dia."}
+
+### Podcast Semana 1
+
+!a[https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-01.mp3] No Princípio
+
+### Podcast Semana 2
+
+!a[https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-02.mp3] Deus Fez a Luz
+
+### Podcast Semana 3
+
+!a[https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-03.mp3] Deus Fez o Céu
+
+### Podcast Semana 4
+
+!a[https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-04.mp3] Deus Fez a Terra Seca
+
+### Podcast Semana 5
+
+!a[https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-05.mp3] Deus Fez as Plantas
+
+### Podcast Semana 6
+
+!a[https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-06.mp3] Deus Fez o Sol, a Lua e as Estrelas
+
+### Podcast Semana 7
+
+!a[https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-07.mp3] Deus Fez a Terra Perfeita
+
+### Podcast Semana 8
+
+!a[https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-08.mp3] Deus Fez os Peixes do Mar
+
+### Podcast Semana 9
+
+!a[https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-09.mp3] Deus Fez as Aves do Céu
+
+### Podcast Semana 10
+
+!a[https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-10.mp3] Deus Fez os Animais
+
+### Podcast Semana 11
+
+!a[https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-11.mp3] Deus Fez Adão e Eva
+
+### Podcast Semana 12
+
+!a[https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-12.mp3] Deus Fez Você
+
+### Podcast Semana 13
+
+!a[https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-13.mp3] Deus Fez o Sábado

--- a/src/pt/aij/2026-01-bg/00-music-and-podcasts/info.yml
+++ b/src/pt/aij/2026-01-bg/00-music-and-podcasts/info.yml
@@ -1,0 +1,1 @@
+title: Música e Podcasts

--- a/src/pt/aij/2026-01-bg/01/01-story.md
+++ b/src/pt/aij/2026-01-bg/01/01-story.md
@@ -1,0 +1,34 @@
+---
+title: No Princípio
+type: story
+audio:
+    src: https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-01.mp3
+---
+
+;;;
+^^^
+{"style":{"image":{"storyTextAlign": "top"}}}
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/01-00.png)
+{"style":{"text":{"color": "#0e7039", "typeface": "Omnes-Bold", "align": "center"}, "block": {"backgroundColor": "#ffffffad"}}}
+No\
+^[Princípio]({"style":{"text":{"color": "#ee6d23", "typeface": "Omnes-BoldItalic"}}})
+^^^
+^^^
+{"style": {"image": {"variants": {"portrait": "hello.png"}}}}
+![](https://sabbath-school-resources-assets.adventech.io/en/devo/test/blocks/story1.png)
+{"style":{"text":{"color": "#ffffff"}}}
+No princípio, antes de haver nuvens brancas e fofas ou lagartas felpudas, havia Deus. Antes de haver estrelas brilhantes ou um oceano tão azul, Deus criou um lugar especial para você. Havia tanto que Ele faria. Em _(conte com os dedos até seis)_ um... dois... três... quatro... cinco... seis dias o mundo seria perfeito e novo. Deus encheria a terra com cores para ver: vermelho, amarelo, azul e verde. Haveria novos sons para ouvir e comida saborosa para comer. O melhor de tudo seriam os amigos que Ele encontraria. Deus é tão bom, e tudo que Ele fez para nós é bom.
+^^^
+^^^
+{"style":{"image":{"storyTextAlign": "top"}}}
+![](https://sabbath-school-resources-assets.adventech.io/en/devo/test/blocks/story2.png)
+{"style":{"text":{"color": "#000000"}}}
+No princípio a terra estava coberta de água. Não havia golfinhos brincalhões ou grandes baleias; nenhum barco pronto para navegar. Deus queria criar um lugar bonito para você estar, com animais grandes _(braços abertos)_ e pequenos _(mãos juntas)_ para você ver. Ele queria fazer pessoas como você (aponte para a criança) e como eu _(aponte para si)_. Então Ele fez. Deus é tão bom, e tudo que Ele fez para nós é bom. No princípio a terra estava vazia e escura. Não havia estrelas brilhantes _(mexa os dedos)_ brilhando na escuridão; nenhuma coruja piando de seus ninhos _(hoo-hoo)_. Deus queria criar um mundo maravilhoso para você ver, cheio de luz tanto para o dia quanto para a noite. Ele queria fazer um dia especial para tempo com você. Então Ele fez. Deus é tão bom, e tudo que Ele fez para nós é bom.
+^^^
+^^^
+{"style":{"image":{"storyTextAlign": "top"}}}
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/01-03.png)
+{"style":{"block": {"backgroundColor": "#ffffffad"},"text":{"color": "#000000"}}}
+No princípio Deus criou os céus e a terra _(aponte para cima e para baixo)_ para você e para mim. Deus encheu a terra com campos gramados e abelhas e riachos borbulhantes e mares quebrantados porque Ele ama você. Ele fez os céus com o sol e a lua para ver. Deus queria criar tudo isso para você e para mim. O que Deus faria no Dia 1? _(Aponte para o círculo com o número 1.)_ Deus é tão bom, e tudo que Ele fez para nós é bom.
+^^^
+;;;

--- a/src/pt/aij/2026-01-bg/01/02-play.md
+++ b/src/pt/aij/2026-01-bg/01/02-play.md
@@ -1,0 +1,41 @@
+---
+title: Brincar Durante o Dia
+markdownTitle: '^[brincar]({"style": {"text": {"color": "#d9b228"}}}) durante o dia'
+cover: https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/01/play-cover.png
+titleBelowCover: true
+style:
+  segment:
+    title:
+      text:
+        typeface: Omnes-BlackItalic
+        align: center
+        color: "#5fb5ac"
+---
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#5EB6AD"}}}
+Criar
+
+Faça um Livro da Criação com seu filho. Use folhas soltas de papel em branco para formar o livro, que pode ser encadernado no final do trimestre. Cada semana um novo dia da criação será adicionado. Esta semana, foque na capa. Peça ao seu filho que pense em algumas de suas coisas favoritas que Deus criou. Encontre e imprima imagens de animais ou plantas, ou desenhe-os juntos na capa da frente. Em seguida, escreva o versículo para memorizar na capa da frente.
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#5EB6AD"}}}
+Explorar
+
+Use brincadeiras com água para aprender sobre a criação de Deus. Encha um caixa de plástico um terço cheia de água. Forneça ao seu filho uma variedade de itens para projetar e criar seu próprio pequeno mundo: pedaços de madeira à deriva, plantas de aquário, seixos, galhos, flores, folhas e peixes de plástico e patinhos.
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#5EB6AD"}}}
+Conectar
+
+Escreva o versículo para memorizar em um pedaço de papel e depois corte cada palavra separadamente. Desenhe uma imagem no verso de cada palavra para ajudar seu filho a entender o que ela diz. Esconda as imagens das palavras ao redor da sala e envie seu filho em uma caça ao tesouro para encontrá-las. Uma vez encontradas, ajude seu filho a colocar as palhas na ordem certa e diga o versículo algumas vezes para aprendê-lo. Não é Deus incrível por criar um mundo tão maravilhoso!
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#5EB6AD"}}}
+Orar
+
+Durante a semana, observe a bondade de Deus e converse sobre isso com seu filho. Explore seu bairro ou quintal pelas coisas boas que Deus fez para nós. Ao descobrir a bondade de Deus com seu filho, pare para dizer "Obrigado" a Deus por cada coisa específica.
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#5EB6AD"}}}
+Aprender
+
+Cante "Deus É Tão Bom" ou outra música que enfatize o amor de Deus com seu filho.
+
+{"style": {"text": {"color": "#5EB6AD", "typeface": "Omnes-Regular"}}}
+**Versículo para memorizar semanal**: "No princípio Deus criou os céus e a terra" (Gênesis 1:1).

--- a/src/pt/aij/2026-01-bg/01/03-the-heart-of-the-matter.md
+++ b/src/pt/aij/2026-01-bg/01/03-the-heart-of-the-matter.md
@@ -1,0 +1,27 @@
+---
+title: O Coração do Assunto
+markdownTitle: 'o ^[CORAÇÃO]({"style": {"text": {"color": "#B1354D"}}}) do ^[ASSUNTO]({"style": {"text": {"color": "#5fb5ac"}}})'
+subtitle: Para Pais
+markdownSubtitle: Para você, Pais
+style:
+  segment:
+    title:
+      text:
+        typeface: BaskervilleBT-Roman
+        align: center
+    subtitle:
+      text:
+        typeface: BaskervilleBT-Roman
+        align: center
+background: https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/01/hm-background.png
+---
+
+Deus realmente é tão bom, e tudo que Deus fez é bom. Deus pegou um espaço vazio e escuro e o encheu com Sua bondade. Ele criou a terra cheia de coisas boas para você e seus filhos! Ele quer que você saiba e veja que Ele é bom. Deus anseia encher sua vida com Sua bondade. Na agitação de cada dia, como isso pode ser facilmente esquecido. "No canto do pássaro e na flor que se abre, na chuva e no sol, na brisa de verão e no orvalho suave, em dez mil objetos na natureza, desde o carvalho da floresta até a violeta que floresce em suas raízes, vê-se o amor que restaura. E a natureza ainda nos fala da bondade de Deus" (Ellen G. White, ^[O Lar Adventista]({"style": {"text": {"typeface": "Omnes-Italic"}}}), p. 47).
+
+Peça a Deus que revele Sua bondade a você durante seus dias agitados. Quanto mais você O busca em cada momento, mais seus olhos estarão abertos para descobri-Lo. Mesmo quando seu dia parecer escuro ou vazio, você começará a ver que Sua bondade está pronta para preencher o vazio. Seja em uma chamada de um amigo ou o nascer do sol cada manhã, a bondade de Deus está ao seu redor. Procure-O, e Ele promete que você O encontrará (Provérbios 8:17). Compartilhe Sua bondade com aqueles ao seu redor, e eles também descobrirão que Ele realmente é bom!
+
+> <callout>1 Crônicas 16:34</callout>
+> "Oh, dai graças ao Senhor, pois Ele é bom! Porque a Sua misericórdia dura para sempre"
+
+> <callout>Salmos 145:9</callout>
+> "O Senhor é bom para todos, e as Suas ternas misericórdias estão sobre todas as Suas obras."

--- a/src/pt/aij/2026-01-bg/01/info.yml
+++ b/src/pt/aij/2026-01-bg/01/info.yml
@@ -1,0 +1,4 @@
+title: No Princípio
+subtitle: Semana 1
+start_date: "28/12/2025"
+end_date: "03/01/2026"

--- a/src/pt/aij/2026-01-bg/02/01-story.md
+++ b/src/pt/aij/2026-01-bg/02/01-story.md
@@ -1,0 +1,34 @@
+---
+title: Deus Fez a Luz
+type: story
+audio:
+    src: https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-02.mp3
+---
+
+;;;
+^^^
+{"style":{"image":{"storyTextAlign": "top"}}}
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/02-00.png)
+{"style":{"text":{"color": "#84b4c1", "typeface": "Omnes-Bold", "align": "center"}, "block":{"backgroundColor": "#181818ad"}}}
+Deus Fez a\
+^[Luz]({"style":{"text":{"color": "#fad656", "typeface": "Omnes-BoldItalic"}}})
+^^^
+^^^
+{"style":{"image":{"storyTextAlign": "top"}}}
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/02-01.png)
+{"style":{"text":{"color": "#ffffff"}}}
+_Sente-se com seu filho sob um cobertor com uma lanterna._ No princípio, antes de haver filhotes de leão se divertindo, ou chitas correndo, havia Deus. Antes de Deus criar a terra para você e para mim, estava escura e vazia. Estava tão escura (sussurre). Nenhum brilho de luz brilhava. Não havia sol ou lua, nem estrelas brilhantes para ver. Deus tinha um plano especial para o Dia 1 (levante um dedo). O tempo chegou, e Ele estava animado para começar! Ele iria fazer um mundo maravilhoso para você e para mim. Este seria o primeiro dia da Criação. Tudo estava quieto, esperando ver o que Deus faria.
+^^^
+^^^
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/02-02.png)
+{"style":{"text":{"color": "#ffffff"}}}
+Então, da escuridão, a voz forte e gentil de Deus ecoou sobre a água: "Haja luz!" (Criança liga a lanterna.) E houve luz! Deus falou, e a escuridão foi embora! Luz brilhou sobre a água cobrindo a terra (mexa os dedos, movendo-os de lado a lado). Deus criou a luz para iluminar cada dia e a separou da escuridão à noite. Foi a primeira manhã na terra. Uma manhã brilhando com as cores da luz. Deus viu a luz e disse que era boa.
+^^^
+^^^
+{"style":{"image":{"storyTextAlign": "top"}}}
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/02-03.png)
+{"style":{"block": {"backgroundColor": "#02addb66"},"text":{"color": "#ffffff"}}}
+Deus fez a luz para encher a terra no Dia 1. Você consegue ver a luz brilhando ao redor? A bela luz de Deus brilha cada dia, um presente de amor para você e para mim (abrace a criança). O plano perfeito de Deus havia começado. Havia muito mais que Deus faria. Cada dia traria algo novo. O que Ele criaria no Dia 2? (Levante dois dedos.)\
+(Diga juntos) Obrigado, Deus, por fazer a luz!
+^^^
+;;;

--- a/src/pt/aij/2026-01-bg/02/02-play.md
+++ b/src/pt/aij/2026-01-bg/02/02-play.md
@@ -1,0 +1,41 @@
+---
+title: Brincar Durante o Dia
+markdownTitle: '^[brincar]({"style": {"text": {"color": "#5cc8d8"}}}) durante o dia'
+cover: https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/02/play-cover.png
+titleBelowCover: true
+style:
+  segment:
+    title:
+      text:
+        typeface: Omnes-BlackItalic
+        align: center
+        color: "#3379be"
+---
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#3379be"}}}
+Criar
+
+Trabalhe no Dia 1 no Livro da Criação do seu filho (da semana passada). Corte papel cartão preto e amarelo em tiras e cole-os para mostrar a diferença entre luz e escuridão. Escreva "No Dia 1 Deus Fez a Luz," no final da página.
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#3379be"}}}
+Explorar
+
+Antes de dormir uma noite, construa uma fortaleza de cobertores e esconda animais de brinquedo nela. Compartilhe como quando a luz brilha na escuridão pode nos ajudar a encontrar as coisas boas que Deus fez. Tire tempo para orar e agradecer a Deus por Sua luz maravilhosa que ilumina nosso mundo.
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#3379be"}}}
+Aprender
+
+A luz é composta de um arco-íris de cores. Encha um copo transparente com água e coloque-o na borda de uma mesa. Coloque uma folha branca de papel no chão a um pé de distância. Brilhe uma lanterna através do copo de água para que a luz seja refratada em cores individuais que brilham no papel. (Algumas lanternas podem precisar de uma pequena fenda para focar o feixe, que pode ser criada usando fita adesiva através da luz.) Louve a Deus por cada uma das belas cores que Ele fez para nós.
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#3379be"}}}
+Cantar
+
+Cante "Esta Pequena Luz" juntos para adoração esta semana. Mova uma lanterna ou vela de pilha enquanto você canta.
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#3379be"}}}
+Orar
+
+Coloque uma corda de luzes de Natal no quarto do seu filho esta semana. Antes de dormir toda noite, tire tempo para orar, agradecendo a Deus por criar a luz. Peça a Jesus para ajudá-lo a ser uma luz brilhante para Ele.
+
+{"style": {"text": {"color": "#3379be", "typeface": "Omnes-Regular"}}}
+**Versículo para memorizar semanal**: "Então Deus disse, 'Haja luz'; e houve luz" (Gênesis 1:3).

--- a/src/pt/aij/2026-01-bg/02/03-the-heart-of-the-matter.md
+++ b/src/pt/aij/2026-01-bg/02/03-the-heart-of-the-matter.md
@@ -1,0 +1,30 @@
+---
+title: O Coração do Assunto
+markdownTitle: 'o ^[CORAÇÃO]({"style": {"text": {"color": "#C1307D"}}}) do ^[ASSUNTO]({"style": {"text": {"color": "#117F4B"}}})'
+subtitle: Para Pais
+markdownSubtitle: Para você, Pais
+style:
+  segment:
+    title:
+      text:
+        typeface: BaskervilleBT-Roman
+        align: center
+    subtitle:
+      text:
+        typeface: BaskervilleBT-Roman
+        align: center
+background: https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/02-04.png
+---
+
+Imagin o som belo e majestoso da voz de Deus ecoando sobre a água. Nos Salmos lemos sobre a voz de Deus como "trovão" e em Apocalipse como o "rugido de muitas águas." É esta mesma voz poderosa e onipotente, que acolheu a luz para iluminar a escuridão, que também gentilmente chama você. Assim como você convida seus filhos para virem sentar com você para compartilhar uma história ou um abraço, Deus também anseia atraí-lo perto, e encher sua vida com Sua luz.
+
+Naquele primeiro dia da Criação a terra estava brilhando com luz, a própria presença de Deus. A luz de Deus é pura e boa. Ela ilumina os lugares escuros e sombreados com Sua bondade. Ela nos conforta quando nossos dias estão sobrecarregados com escuridão, e nos lembra que cada manhã é um novo dia fresco.
+
+Você pode ter momentos em que seu dia está cheio, mas você se sente vazio. Você tropeçou em brinquedos ou limpou comida do chão uma vez demais, sua energia e paciência drenadas. É nesses momentos que pode ser mais difícil responder ao Seu convite.
+
+Respire fundo, expire uma oração, ou cante um louvor a Deus. "O cântico tem poder maravilhoso. Tem poder para subjugar naturezas rudes e incultas; poder para despertar o pensamento e despertar simpatia, promover harmonia de ação, e banir a melancolia e o pressentimento que destroem a coragem e enfraquecem o esforço" (Ellen G. White, ^[Educação]({"style": {"text": {"typeface": "Omnes-Italic"}}}), p. 168).
+
+Sua luz brilhará em seu coração. Não pode ser contida. A gloriosa luz de Deus irradiará através de sua vida, renovando seu espírito e enchendo seu lar com Sua bondade.
+
+> <callout>2 Coríntios 4:6, 7, NVI</callout>
+> "Deus uma vez disse, 'Que a luz resplandeça das trevas!' E este é o mesmo Deus que fez Sua luz resplandecer em nossos corações. Ele nos deu luz deixando-nos conhecer a glória de Deus que está no rosto de Cristo. Temos este tesouro de Deus. Mas somos apenas como vasos de barro que seguram o tesouro. Isso mostra que este grande poder é de Deus, não de nós"

--- a/src/pt/aij/2026-01-bg/02/info.yml
+++ b/src/pt/aij/2026-01-bg/02/info.yml
@@ -1,0 +1,4 @@
+title: Deus Fez a Luz
+subtitle: Semana 2
+start_date: "04/01/2026"
+end_date: "10/01/2026"

--- a/src/pt/aij/2026-01-bg/03/01-story.md
+++ b/src/pt/aij/2026-01-bg/03/01-story.md
@@ -1,0 +1,34 @@
+---
+title: Deus Fez o Céu
+type: story
+audio:
+    src: https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-03.mp3
+---
+
+;;;
+^^^
+{"style":{"image":{"storyTextAlign": "top"}}}
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/03-00.png)
+{"style":{"text":{"color": "#fcee87", "typeface": "Omnes-Bold", "align": "center"}, "block":{"backgroundColor": "#e1e1e1ad"}}}
+Deus Fez\
+^[o Céu]({"style":{"text":{"color": "#3d66a3", "typeface": "Omnes-BoldItalic"}}})
+^^^
+^^^
+{"style":{"image":{"storyTextAlign": "top"}}}
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/03-01.png)
+{"style":{"text":{"color": "#ffffff"}}}
+No princípio, antes de haver pássaros que voam, ou vacas que mugem, havia Deus. Deus queria que houvesse um mundo bonito para mim e para você. No Dia 1 (um dedo) Deus encheu a terra com Sua bela luz. Havia muito mais que Deus faria agora no Dia 2 (dois dedos). Era uma manhã brilhante e nova. A luz brilhava na água cobrindo a terra. Deus tinha um plano maravilhoso para o Dia 2 (dois dedos). Ele estava pronto para começar. Tudo estava quieto; a terra estava prestes a mudar. O que Deus estava prestes a fazer?
+^^^
+^^^
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/03-02.png)
+{"style":{"block": {"backgroundColor": "#02addb66"},"text":{"color": "#ffffff"}}}
+Sobre a água ecoou a voz forte e gentil de Deus. Deus disse às águas para se dividirem em duas (mãos juntas, depois separadas). Alguma água foi para cima, para cima, para cima (mão para cima), e alguma água ficou para baixo, para baixo, para baixo (mova a outra mão de lado a lado abaixo). Deus falou, e houve ar! "Deus chamou o ar, 'céu' " (Gênesis 1:8, NVI). Céu azul e ar fresco encheram a terra (respire e expire com seu filho). Uma brisa suave soprou sobre a água brilhante (sopre sobre sua mão). A água brilhava com o azul do novo céu. Um dia o céu regaria a terra com chuva de nuvens fofas que flutuariam por aqui.
+^^^
+^^^
+{"style":{"image":{"storyTextAlign": "top"}}}
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/03-03.png)
+{"style":{"block": {"backgroundColor": "#ffffffad"},"text":{"color": "#00796a"}}}
+Deus fez o céu para mim e para você, Seu presente especial no Dia 2. Quando você sentir o vento em suas bochechas e ver as nuvens no céu, você saberá que Ele é bom. Quando você respirar fundo o ar que Deus fez, você saberá que Ele ama você (abrace a criança). O plano de Deus ainda não estava feito. Cada dia haveria mais para ver. O que você acha que Ele fará no Dia 3? (Três dedos.)\
+(Diga juntos) Obrigado, Deus, por fazer o céu!
+^^^
+;;;

--- a/src/pt/aij/2026-01-bg/03/02-play.md
+++ b/src/pt/aij/2026-01-bg/03/02-play.md
@@ -1,0 +1,41 @@
+---
+title: Brincar Durante o Dia
+markdownTitle: '^[brincar]({"style": {"text": {"color": "#e7b621"}}}) durante o dia'
+cover: https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/03-05.png
+titleBelowCover: true
+style:
+  segment:
+    title:
+      text:
+        typeface: Omnes-BlackItalic
+        align: center
+        color: "#61b69e"
+---
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#61b69e"}}}
+Criar
+
+Trabalhe no Dia 2 do Livro da Criação do seu filho. Use aquarela azul ou lápis de cor para criar o céu. Separe bolas de algodão e cole-as para as nuvens. Escreva "No Dia 2 Deus Fez o Céu."
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#61b69e"}}}
+Descobrir
+
+Descubra o efeito do vento. Soprem bolhas juntos ou veja um cata-vento se mover. Voe uma pipa ou faça um avião de papel. Converse sobre como o vento faz todas essas coisas se moverem.
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#61b69e"}}}
+Explorar
+
+Deitem em um cobertor juntos e olhem para as nuvens. Encoraje seu filho a usar sua imaginação e nomear formas e imagens de nuvens. Converse sobre como elas se movem com o ar que Deus fez. Louve a Deus pelo lindo céu azul e nuvens flutuando por aqui.
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#61b69e"}}}
+Aprender
+
+Explore na natureza coisas que sopram no vento: penas, folhas, dentes-de-leão, sementes, ou gramas altas. Compartilhe como essas coisas precisam do vento para ajudá-las a se espalhar e crescer novamente. Observe pássaros planando ou borboletas flutuando por aqui. Procure alguns livros de natureza na biblioteca sobre sementes e folhas.
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#61b69e"}}}
+Orar
+
+Respire, expire. Agradeça a Deus pelo ar que você respira, e pelo vento que sopra.
+
+{"style": {"text": {"color": "#61b69e", "typeface": "Omnes-Regular"}}}
+**Versículo para memorizar semanal**: "Pela palavra do Senhor foram feitos os céus" (Salmos 33:6).

--- a/src/pt/aij/2026-01-bg/03/03-the-heart-of-the-matter.md
+++ b/src/pt/aij/2026-01-bg/03/03-the-heart-of-the-matter.md
@@ -1,0 +1,31 @@
+---
+title: O Coração do Assunto
+markdownTitle: 'o ^[CORAÇÃO]({"style": {"text": {"color": "#65519E"}}}) do ^[ASSUNTO]({"style": {"text": {"color": "#009051"}}})'
+subtitle: Para Pais
+markdownSubtitle: Para você, Pais
+style:
+  segment:
+    title:
+      text:
+        typeface: BaskervilleBT-Roman
+        align: center
+    subtitle:
+      text:
+        typeface: BaskervilleBT-Roman
+        align: center
+background: https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/03-04.png
+---
+
+Deus pinta Sua beleza na tela do céu diferentemente cada dia através dos tempos e estações. Tire algum tempo hoje para absorver a vasta beleza do céu de Deus. Note os vários padrões de nuvens; maravilhe-se com os rosas polidos de um pôr do sol ou o tom dourado de um nascer do sol. Observe uma tempestade se reunindo no horizonte enquanto nuvens escuras se formam e então liberam suas chuvas.
+
+Se Deus pode pintar o céu todos os dias com tanta beleza, o que Ele pode fazer em sua vida esta semana? Prazos de trabalho, cestas de roupa cheias e o redemoinho de sempre chegar em algum lugar a tempo não estão além de Seu cuidado. Deus ama tanto ordem quanto beleza. O Deus que criou o céu quer presentear você com ambos.
+
+Rotinas e estrutura são importantes tanto para crianças quanto para adultos. Um senso de paz pode ser encontrado em seus próprios planos diários. Saber o que virá em cada dia dá conforto e segurança a uma criança para explorar e aprender. Mas não importa como perfeitamente ordenado seu dia começa, haverá momentos em que você se sentirá fora de controle, como uma tempestade se formando no horizonte. Como você responde quando seus planos parecem se desintegrar? A quem você recorre para sua estabilidade e conforto?
+
+Quando você mostra ao seu filho que você pode calidamente se ajustar a um novo curso, eles também aprendem como lidar com mudanças inesperadas. Juntos vocês podem pedir a Deus para ordenar seus planos. Busque Sua força para ser flexível não importa o que surja enquanto você modela ao seu filho como confiar nEle. Suas ansiedades podem ser aliviadas quando você descansar sabendo que Deus segura o mundo, e seu lar, em Suas mãos.
+
+> <callout>Jó 37:16</callout>
+> "Sabes tu como são equilibradas as nuvens, essas obras maravilhosas daquele que é perfeito em conhecimento?"
+
+> <callout>Ellen G. White, Educação, pp. 99, 100</callout>
+> "O mesmo poder que sustenta a natureza está trabalhando também no homem. . . . Só em harmonia com Ele pode ser encontrado seu verdadeiro esfera de ação. Para todos os objetos de Sua criação a condição é a mesma—uma vida sustentada recebendo a vida de Deus, uma vida exercida em harmonia com a vontade do Criador"

--- a/src/pt/aij/2026-01-bg/03/info.yml
+++ b/src/pt/aij/2026-01-bg/03/info.yml
@@ -1,0 +1,4 @@
+title: Deus Fez o Céu
+subtitle: Semana 3
+start_date: "11/01/2026"
+end_date: "17/01/2026"

--- a/src/pt/aij/2026-01-bg/04/01-story.md
+++ b/src/pt/aij/2026-01-bg/04/01-story.md
@@ -1,0 +1,34 @@
+---
+title: Deus Fez a Terra Seca
+type: story
+audio:
+    src: https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-04.mp3
+---
+
+;;;
+^^^
+{"style":{"image":{"storyTextAlign": "top"}}}
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/04-00.png)
+{"style":{"text":{"color": "#f9ee3f", "typeface": "Omnes-Bold", "align": "center"}, "block":{"backgroundColor": "#a68585ad"}}}
+Deus Fez\
+^[a Terra Seca]({"style":{"text":{"color": "#3578bd", "typeface": "Omnes-BoldItalic"}}})
+^^^
+^^^
+{"style":{"image":{"storyTextAlign": "top"}}}
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/04-01.png)
+{"style":{"text":{"color": "#ffffff"}}}
+No princípio, antes de haver corujas nas árvores ou tartarugas nos mares, havia Deus. Era o Dia 3, e Deus tinha estado ocupado criando um lugar para você e para mim. No Dia 1 (levante um dedo) Deus criou a luz. No Dia 2 (dois dedos) Deus criou o céu. Ainda havia mais para ser feito. A terra estava coberta de água, sem lugar para nós estar. Era a manhã do Dia 3 (três dedos). Uma brisa suave soprou (sopre sobre sua mão), e o céu (mova a mão em um arco sobre sua cabeça) brilhava brilhante e azul. A luz brilhava na água cobrindo a terra. O que Deus tinha reservado para nós ver?
+^^^
+^^^
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/04-02.png)
+{"style":{"text":{"color": "#ffffff"}}}
+A voz forte e gentil de Deus ecoou sobre a água. Deus disse à água para se mover junto e a terra seca para aparecer. Ao Seu comando a água correu para um lugar (mova as mãos para um lado), e a terra e as rochas empurraram para cima através da água! (Empurre as mãos para cima.) "Deus chamou a terra seca 'terra.' Ele chamou a água . . . 'mares' " (Gênesis 1:10, NVI). Colinas rolando de terra marrom profundo podiam ser vistas. Rochas coloridas brilhavam no chão. Água borbulhava (faça um movimento rolando com as mãos) da terra e tornou-se riachos gentis e rios rugindo que se juntaram ao grande mar. Deus viu (mão acima dos olhos; olhe ao redor) tudo que Ele tinha feito, e era bom.
+^^^
+^^^
+{"style":{"image":{"storyTextAlign": "top"}}}
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/04-03.png)
+{"style":{"block": {"backgroundColor": "#ffffffad"},"text":{"color": "#000000"}}}
+Toda essa bondade Deus fez para você e para mim. Quando você brinca na terra marrom quente, o que você vê? Rochas vermelhas ou amarelas, minhocas rastejando ou sementes crescendo no chão? Você faz estradas através da terra ou rios de água fluindo? O plano maravilhoso de Deus tinha mais para nós ver. Ele fez a terra seca para nossas casas e jardins serem. O que mais Ele faria para nós no Dia 3?\
+(Diga juntos) Obrigado, Deus, por fazer a terra e o mar!
+^^^
+;;;

--- a/src/pt/aij/2026-01-bg/04/02-play.md
+++ b/src/pt/aij/2026-01-bg/04/02-play.md
@@ -1,0 +1,41 @@
+---
+title: Brincar Durante o Dia
+markdownTitle: '^[brincar]({"style": {"text": {"color": "#396bb4"}}}) durante o dia'
+cover: https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/04-05.png
+titleBelowCover: true
+style:
+  segment:
+    title:
+      text:
+        typeface: Omnes-BlackItalic
+        align: center
+        color: "#66b9e8"
+---
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#66b9e8"}}}
+Criar
+
+Ajude seu filho a criar uma página do Dia 3 em seu Livro da Criação. Crie um cenário de terra e água. Use papel cartão colorido para cortar a forma de colinas. Corte algumas, usando papel cartão de cores diferentes, e depois cole-as umas sobre as outras para formar um cenário de muitas montanhas. Crie um lago ou lagoa em primeiro plano. Você adicionará plantas e árvores a esta página na próxima semana.
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#66b9e8"}}}
+Construir
+
+Use areia cinética ou terra para seu filho descobrir mais sobre a criação de Deus. Forneça-lhes uma variedade de itens, como rochas de rio, casca de árvore, pequenas pás e tratores para projetar e criar suas próprias colinas e vales. Se usar terra, adicione água para fazer lagoas ou rios.
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#66b9e8"}}}
+Descobrir
+
+Vá caminhar ao longo de um rio ou praia e procure por rochas ou conchas de cores e formas diferentes. Colete um bolso cheio para trazer para casa e adicionar à brincadeira de terra do seu filho ou coleção de jardim. Você também pode esconder algumas para elas encontrarem.
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#66b9e8"}}}
+Explorar
+
+Vá para fora e aprenda sobre animais que vivem na terra. Leve uma pequena pá e uma lupa para procurar minhocas e insetos. Agradeça a Deus por Sua criação maravilhosa, mesmo as coisas pequenas que não vemos frequentemente!
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#66b9e8"}}}
+Orar
+
+Pinte rochas para representar algumas das coisas que Deus criou (você pode querer pintar uma para cada dia da Criação enquanto ensina seu filho sobre a semana da Criação). Agradeça a Deus pelo que Ele criou cada dia. Encontre um lugar em seu quintal para criar um caminho de oração e louvor usando suas rochas pintadas, ou compartilhe-as com um vizinho ou membro da família para lembrá-los que a criação de Deus nos fala de Seu amor.
+
+{"style": {"text": {"color": "#66b9e8", "typeface": "Omnes-Regular"}}}
+**Versículo para memorizar semanal**: "E Deus viu que era bom" (Gênesis 1:12).

--- a/src/pt/aij/2026-01-bg/04/03-the-heart-of-the-matter.md
+++ b/src/pt/aij/2026-01-bg/04/03-the-heart-of-the-matter.md
@@ -1,0 +1,28 @@
+---
+title: O Coração do Assunto
+markdownTitle: 'o ^[CORAÇÃO]({"style": {"text": {"color": "#B85C39"}}}) do ^[ASSUNTO]({"style": {"text": {"color": "#009559"}}})'
+subtitle: Para Pais
+markdownSubtitle: Para você, Pais
+style:
+  segment:
+    title:
+      text:
+        typeface: BaskervilleBT-Roman
+        align: center
+    subtitle:
+      text:
+        typeface: BaskervilleBT-Roman
+        align: center
+background: https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/04-04.png
+---
+
+A água correu para estar dentro dos limites que Deus designou para ela. Rios e lagos fluíam dentro de suas margens, o mar em seu lugar. Esses limites manteriam a água de cobrir a terra seca, criando espaço onde as coisas cresceriam. Deus, em Sua infinita sabedoria e criatividade, criou rios serpenteantes bonitos e oceanos com os limites necessários para fornecer o equilíbrio necessário entre água e terra.
+
+Limites também oferecem o equilíbrio necessário na criação de um filho de Deus. Eles dão não apenas estrutura mas também segurança para seu filho. Quando limites apropriados à idade são estabelecidos com amor e graça, uma criança aprende autocontrole, confiança e autoestima. Elas descobrem como respeitar as necessidades dos outros bem como como expressar as suas. Crianças buscarão onde esses limites estão, então seja claro e consistente. Assim como um rio que procura o caminho de menor resistência para fluir, é natural para uma criança testar esses limites. Dê ao seu filho oportunidades para fazer escolhas dentro dos limites que você cria. Quando esses limites são violados, gentil e amorosamente coloque seu filho de volta em um caminho sólido. Ore por sabedoria enquanto você estabelece esses limites cheios de graça para atender às necessidades do seu filho. Deleite-se no crescimento deles enquanto encontram o caminho da alegria através de tudo que Deus amorosamente criou para eles.
+
+> <callout>Provérbios 22:6</callout>
+> "Ensina a criança no caminho em que deve andar, e, ainda quando for velho, não se desviará dele"
+
+
+> <callout>Ellen G. White, ^[O Desejado de Todas as Nações]({"style": {"text": {"typeface": "Omnes-Italic"}}}), p. 516</callout>
+> "Pais, no treinamento de seus filhos, estudem as lições que Deus deu na natureza. . . . Perguntem ao jardineiro por que processo ele faz cada ramo e folha florescer tão belamente, e desenvolver em simetria e formosura. . . . Por toques gentis, por ministérios amorosos, busquem moldar seus caracteres após o padrão do caráter de Cristo"

--- a/src/pt/aij/2026-01-bg/04/info.yml
+++ b/src/pt/aij/2026-01-bg/04/info.yml
@@ -1,0 +1,4 @@
+title: Deus Fez a Terra Seca
+subtitle: Semana 4
+start_date: "18/01/2026"
+end_date: "24/01/2026"

--- a/src/pt/aij/2026-01-bg/05/01-story.md
+++ b/src/pt/aij/2026-01-bg/05/01-story.md
@@ -1,0 +1,33 @@
+---
+title: Deus Fez as Plantas
+type: story
+audio:
+    src: https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-05.mp3
+---
+
+;;;
+^^^
+{"style":{"image":{"storyTextAlign": "top"}}}
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/05-00.png)
+{"style":{"text":{"color": "#4e7d3a", "typeface": "Omnes-Bold", "align": "center"}, "block":{"backgroundColor": "#e1e1e1ad"}}}
+Deus Fez as\
+^[Plantas]({"style":{"text":{"color": "#b34097", "typeface": "Omnes-BoldItalic"}}})
+^^^
+^^^
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/05-01.png)
+{"style":{"text":{"color": "#ffffff"},"block":{"backgroundColor": "#5f5f5fad"}}}
+No princípio, antes de haver macieiras ou abelhas, havia Deus. Deus tinha estado ocupado fazendo um lugar para você e para mim. Quando o Dia 3 começou (levante três dedos), Deus moveu a água para fazer terra seca. Ele tinha feito a luz no Dia 1 (levante um dedo) e o céu no Dia 2 (levante dois dedos). Ainda nada crescia, nenhum jardim ou flores, cerejeiras ou sementes. Havia mais para fazer no Dia 3, muito mais para ser visto. Um riacho azul rolou pelas colinas rolantes de terra marrom rica. Uma brisa quieta ondulou a água do mar brilhante. O céu estava brilhante e claro. O que Deus faria a seguir para você e para mim? (Mãos abertas como em uma pergunta.)
+^^^
+^^^
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/05-02.png)
+{"style":{"text":{"color": "#ffffff"},"block":{"backgroundColor": "#5f5f5fad"}}}
+A voz forte e gentil de Deus ecoou sobre as colinas. Deus falou, e grama verde suave começou a crescer. Ela empurrou através da terra e cobriu as ladeiras. Flores estouraram (mãos fechadas juntas, depois estouraram para cima e abriram) do solo: violetas roxas, girassóis amarelos, e margaridas brancas encheram os prados. Macieiras e pereiras e carvalhos fortes empurraram seu caminho através da terra, alcançando em direção ao céu. Árvores ficaram altas com maçãs vermelhas saborosas e mangas doces pendurando em folhas verdes. Bananas e cocos penduraram de galhos em palmeiras. Girassóis altos balançaram suas cabeças na brisa. Cenouras laranjas com seus topos verdes arbustos empurraram através da terra enquanto as fileiras ordenadas de um jardim começaram a aparecer. Deus viu (mão acima dos olhos; olhe ao redor) tudo que Ele tinha feito, e era bom.
+^^^
+^^^
+{"style":{"image":{"storyTextAlign": "top"}}}
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/05-03.png)
+{"style":{"block": {"backgroundColor": "#ffffffad"},"text":{"color": "#000000"}}}
+Deus fez um mundo bonito cheio de cores brilhantes para ver, flores doces para cheirar, e frutas e vegetais para comer. Ele deu a cada planta sementes para que mais crescesse. Ele fez todas essas coisas boas para você e para mim. Você gosta de comer uma maçã crocante ou uma laranja suculenta? Você gosta de comer ervilhas verdes minúsculas ou pão feito de trigo? Deus fez essas comidas deliciosas para você aproveitar e para ajudá-lo a crescer. Deus ama você tanto! (Abraçe seu filho.) O que Deus teria reservado no Dia 4?\
+(Diga juntos) Obrigado, Deus, por fazer as plantas e árvores crescerem!
+^^^
+;;;

--- a/src/pt/aij/2026-01-bg/05/02-play.md
+++ b/src/pt/aij/2026-01-bg/05/02-play.md
@@ -1,0 +1,41 @@
+---
+title: Brincar Durante o Dia
+markdownTitle: '^[brincar]({"style": {"text": {"color": "#f8972b"}}}) durante o dia'
+cover: https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/05-05.png
+titleBelowCover: true
+style:
+  segment:
+    title:
+      text:
+        typeface: Omnes-BlackItalic
+        align: center
+        color: "#53ba5b"
+---
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#53ba5b"}}}
+Criar
+
+Continue trabalhando no Dia 3 do Livro da Criação do seu filho. Colete folhas, galhos e flores de fora (ou corte imagens) para criar um colagem no topo das montanhas que você fez na semana passada. Use cola forte para prendê-las ao papel. Crie árvores, arbustos, grama e flores. Escreva no final da página "No Dia 3 Deus fez terra seca, plantas e árvores."
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#53ba5b"}}}
+Conectar
+
+Na sexta-feira vá e colha flores juntos (ou compre algumas da loja), prontas para o Sábado. Peça ao seu filho para organizá-las em dois buquês, um para sua mesa e outro para compartilhar com um vizinho ou amigo. Agradeça a Deus pelas lindas flores que Ele criou.
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#53ba5b"}}}
+Aprender
+
+Cole cinco hastes de tiras de papel verde em papel pesado. No topo de cada haste, cole uma forminha de papel de muffin de cor diferente. Dê ao seu filho itens para classificar (como pompons ou botões grandes) na flor de cor correspondente.
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#53ba5b"}}}
+Explorar
+
+Dê um passeio para descobrir o que Deus fez no Dia 3. Colete pinhas, flores, folhas e gramas diferentes. Olhe para os detalhes da vida que Deus criou em cada item que você encontra—as sementes em uma pinha ou girassol, o pólen de uma flor, e as veias de uma folha. Classifique os itens por cor, forma e tamanho. Adicione-os a uma caixa criativa para seu filho brincar e adicionar terra para fazer seu próprio jardim.
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#53ba5b"}}}
+Orar
+
+Desenhe e corte uma flor simples de cinco pétalas. Escreva no centro "Obrigado, Deus." Em cada pétala, escreva algo pelo qual você é grato. Complete uma flor quantas vezes quiser esta semana e crie um jardim de gratidão. Convide outros membros da família a adicionarem suas próprias flores também.
+
+{"style": {"text": {"color": "#53ba5b", "typeface": "Omnes-Regular"}}}
+**Versículo para memorizar semanal**: "Então Deus disse, 'Que a terra produza grama . . . e a árvore frutífera' " (Gênesis 1:11).

--- a/src/pt/aij/2026-01-bg/05/03-the-heart-of-the-matter.md
+++ b/src/pt/aij/2026-01-bg/05/03-the-heart-of-the-matter.md
@@ -1,0 +1,28 @@
+---
+title: O Coração do Assunto
+markdownTitle: 'o ^[CORAÇÃO]({"style": {"text": {"color": "#C43839"}}}) do ^[ASSUNTO]({"style": {"text": {"color": "#00AC57"}}})'
+subtitle: Para Pais
+markdownSubtitle: Para você, Pais
+style:
+  segment:
+    title:
+      text:
+        typeface: BaskervilleBT-Roman
+        align: center
+    subtitle:
+      text:
+        typeface: BaskervilleBT-Roman
+        align: center
+background: https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/05-04.png
+---
+
+As ladeiras estavam estourando com nova vida. Botões de ouro e margaridas pontilharam as colinas rolantes de grama verde; arbustos estavam carregados de flores de lilás cheirosas. Árvores sempre verdes altas e majestosas ficaram de guarda enquanto bosques de árvores frutíferas pendiam pesadas com pêssegos doces e suculentos. A terra estava vestida de beleza fragrante, e nova vida estava crescendo abundantemente.
+
+Podemos ver o amor e sabedoria de Deus em Suas obras criadas enquanto nos maravilhamos com a grandeza dos Alpes, o design cuidadoso das flores, ou o suave bater de asas de uma borboleta. Quão perfeito e bonito era este mundo antes do pecado, sem folhas mortas ou espinhos, sem invernos congelantes ou verões escaldantes. Tire algum tempo em sua agitação para pensar sobre como a criação original e perfeita de Deus refletia Seu caráter. Converse com seu filho sobre isso também. Ao nosso redor ainda podemos ver evidências de nosso Deus Criador poderoso e Seu caráter perfeito, mas a natureza não pode mais nos fornecer um conhecimento perfeito do amor e vontade de Deus.
+
+"Deus prendeu nossos corações a Ele com inúmeros sinais no céu e na terra. Através das coisas da natureza, e os laços terrestres mais profundos e ternos que os corações humanos podem conhecer, Ele buscou revelar-Se a nós. Mas esses mas imperfeitamente representam Seu amor" (Ellen G. White, ^[Caminho a Cristo]({"style": {"text": {"typeface": "Omnes-Italic"}}}), p. 10).
+
+Deus é tão bom por nos ter dado a Bíblia—uma revelação confiável e duradoura de Seu caráter, que nos diz mais claramente de Seu infinito amor por nós!
+
+> <callout>1 João 4:16</callout>
+> "E temos conhecido e crido o amor que Deus tem por nós. Deus é amor, e aquele que permanece no amor permanece em Deus, e Deus nele"

--- a/src/pt/aij/2026-01-bg/05/info.yml
+++ b/src/pt/aij/2026-01-bg/05/info.yml
@@ -1,0 +1,4 @@
+title: Deus Fez as Plantas
+subtitle: Semana 5
+start_date: "25/01/2026"
+end_date: "31/01/2026"

--- a/src/pt/aij/2026-01-bg/06/01-story.md
+++ b/src/pt/aij/2026-01-bg/06/01-story.md
@@ -1,0 +1,33 @@
+---
+title: Deus Fez o Sol, a Lua e as Estrelas
+type: story
+audio:
+    src: https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-06.mp3
+---
+
+;;;
+^^^
+{"style":{"image":{"storyTextAlign": "top"}}}
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/06-00.png)
+{"style":{"text":{"color": "#975233", "typeface": "Omnes-Bold", "align": "center"}, "block":{"backgroundColor": "#e1e1e1ad"}}}
+Deus Fez\
+^[Sol, Lua,]({"style":{"text":{"color": "#5e4235", "typeface": "Omnes-BoldItalic"}}}) e ^[Estrelas]({"style":{"text":{"color": "#5e4235", "typeface": "Omnes-BoldItalic"}}})
+^^^
+^^^
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/06-01.png)
+{"style":{"text":{"color": "#1f5d40"},"block":{"backgroundColor": "#e1e1e1ad"}}}
+No princípio, antes de haver ursos que roncam ou águias que planam, havia Deus.  No Dia 1 Ele fez a luz (um dedo). No Dia 2 Ele fez o céu (dois dedos). No Dia 3 Ele fez a terra e o mar, e grama tão verde (três dedos). Era agora o Dia 4 (levante quatro dedos). Deus criou um mundo bonito para você e para mim. O novo dia brilhava enquanto uma brisa suave soprava através das árvores.  O cheiro de rosas e laranjas doces encheu o ar. Deus tinha estado criando um mundo que Ele queria compartilhar.  O rio rolou (role as mãos em movimento rolando) para o mar brilhante, e as gramas altas dançaram na praia.  O tempo chegou para Deus mostrar o que seria feito no Dia 4 (quatro dedos).
+^^^
+^^^
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/06-02.png)
+{"style":{"text":{"color": "#ffffff"}}}
+A voz forte e gentil de Deus ecoou sobre as colinas. Enquanto Ele falou, a Terra ficou quente e cheia de luz brilhante do sol.  O dia estava quente e brilhante enquanto o céu encheu de cores e luz. Pontos brilhantes brilharam no céu noturno enquanto Deus colocou milhões (movimento expansivo dos braços) de estrelas para brilhar bem alto lá em cima. Ele pendurou a grande lua redonda para brilhar, refletindo o sol à noite. Deus colocou essas luzes nos céus para dar luz à Terra e para separar o dia da noite.  Deus viu (mão acima dos olhos; olhe ao redor) tudo que Ele tinha feito, e era bom. A tarde passou, e a manhã veio. Este foi o quarto dia.
+^^^
+^^^
+{"style":{"image":{"storyTextAlign": "top"}}}
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/06-03.png)
+{"style":{"block": {"backgroundColor": "#ffffffad"},"text":{"color": "#000000"}}}
+Deus fez o sol, estrelas e lua para você e para mim. A luz solar faz sua pele sentir quente e ajuda você a crescer. Você consegue assistir a lua mudar noite após noite de um crescente prateado no céu para cheio e brilhante?  Você consegue contar as estrelas cada noite enquanto começam a brilhar? Deus fez esta Terra tão fina. Ele ama você, e eu também! O que viria a seguir no Dia 5?\
+(Diga juntos) Obrigado, Deus, por fazer o sol, a lua e as estrelas!
+^^^
+;;;

--- a/src/pt/aij/2026-01-bg/06/02-play.md
+++ b/src/pt/aij/2026-01-bg/06/02-play.md
@@ -1,0 +1,41 @@
+---
+title: Brinque Durante o Dia
+markdownTitle: '^[brinque]({"style": {"text": {"color": "#694d9f"}}}) durante o dia'
+cover: https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/06-05.png
+titleBelowCover: true
+style:
+  segment:
+    title:
+      text:
+        typeface: Omnes-BlackItalic
+        align: center
+        color: "#2a459c"
+---
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#2a459c"}}}
+Crie
+
+No Dia 4 do Livro da Criação do seu filho, recorte cartão azul claro para preencher metade da página, e cartão preto ou azul marinho para preencher a outra metade. Use papel amarelo para recortar um sol e use tiras de papel amarelo e laranja para os raios. Use adesivos de estrelas brilhantes para preencher o céu noturno e recorte uma forma de crescente para a lua. Escreva embaixo: "No Dia 4 Deus criou o sol, a lua e as estrelas."
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#2a459c"}}}
+Explore
+
+Em um dia ensolarado, leve seu filho para fora por alguns minutos para sentir o calor do sol na grama, na terra ou no pavimento, depois entre para sentir o frescor da sombra. Converse com seu filho sobre passar protetor solar e usar chapéu e óculos de sol para ajudar a obter a quantidade certa de sol, mas não demais. Agradeça a Deus pelo sol, que nos ajuda a ficar aquecidos.
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#2a459c"}}}
+Aprenda
+
+Colete alguns livros da biblioteca local sobre o sol, a lua e as estrelas. Aprenda sobre as estrelas no céu e mostre ao seu filho qual planeta é a Terra na fila de planetas. Pesquise algumas fotos de estrelas de perto. Recorte as diferentes fases da lua e cole-as em linha para mostrar o que a lua faz durante o mês. Que Deus incrível para criar um universo tão enorme!
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#2a459c"}}}
+Observe
+
+Plante algumas sementes de flores (como margaridas) em um vaso e coloque em uma janela ensolarada. À medida que crescem e florescem, agradeça a Deus por fazer o sol para ajudar as coisas a crescerem.
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#2a459c"}}}
+Ore
+
+Vá para fora e segure seu filho enquanto vocês observam o pôr do sol. Converse sobre as belas cores que Deus pinta no céu. Quando o crepúsculo chegar, procure as primeiras estrelas a brilharem e veja quantas vocês podem contar. À medida que o céu fica mais escuro, procure a faixa leitosa de estrelas chamada Via Láctea. Converse sobre como Deus fez as estrelas e conhece cada uma por nome. Compartilhe como Deus também conhece o nome do seu filho, e sabe até quantos fios de cabelo estão na sua cabeça.
+
+{"style": {"text": {"color": "#2a459c", "typeface": "Omnes-Regular"}}
+**Versículo memorável semanal adicional**: "Deus fez os dois grandes luminares... Fez também as estrelas" (Gênesis 1:16).

--- a/src/pt/aij/2026-01-bg/06/03-the-heart-of-the-matter.md
+++ b/src/pt/aij/2026-01-bg/06/03-the-heart-of-the-matter.md
@@ -1,0 +1,28 @@
+---
+title: O Coração da Questão
+markdownTitle: 'o ^[CORAÇÃO]({"style": {"text": {"color": "#C43839"}}}) da ^[QUESTÃO]({"style": {"text": {"color": "#006EB6"}}})'
+subtitle: Para Pais
+markdownSubtitle: Para você, Pais
+style:
+  segment:
+    title:
+      text:
+        typeface: BaskervilleBT-Roman
+        align: center
+    subtitle:
+      text:
+        typeface: BaskervilleBT-Roman
+        align: center
+background: https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/06-04.png
+---
+
+Você já olhou para o céu noturno e se sentiu sobrecarregado com a enorme vastidão do universo? Há aproximadamente 4.500 estrelas que podemos ver à noite apenas com nossos olhos. Somente na Via Láctea, os astrônomos estimam que existam 100 bilhões de estrelas! Usando o Telescópio Hubble, eles estimam que existam cerca de 1 x 10²⁴ — ou seja, 1 septilhões (ou 1 septiljoen em português europeu) — estrelas no universo conhecido!
+
+A Bíblia menciona estrelas em vários lugares. Em Salmos 147:4, 5, diz: "Ele conta o número das estrelas; chama-as todas pelo nome. Grande é o nosso Senhor, e grande em poder; o seu entendimento é infinito."
+
+Apocalipse 12 descreve anjos caídos como "estrelas". Lemos sobre o dragão, Satanás, e sua cauda, que "arrastou a terça parte das estrelas do céu e as lançou à terra" (Apocalipse 12:4). Depois que "houve batalha no céu: Miguel e os seus anjos batalhavam contra o dragão; e batalhavam o dragão e os seus anjos; mas não prevaleceram, nem mais o seu lugar se achou no céu. E foi precipitado o grande dragão, a antiga serpente, chamada o Diabo e Satanás, que engana todo o mundo; ele foi precipitado na terra, e os seus anjos foram precipitados com ele" (Apocalipse 12:7-9).
+
+Ter um entendimento disso é vital para nós como pais, porque há uma batalha invisível (também chamada de grande controvérsia) acontecendo aqui na terra; e agora é a mais feroz que já foi. Esta batalha muito real está acontecendo por você e seus filhos, e Deus pede sua lealdade a Ele enquanto Ele ajuda você a criar seu pequeno. Ele lutará a batalha por você enquanto você permanece Nele, como Ele fez vez após vez pelo Seu povo ao longo da história da Terra. "Em todas as eras, anjos têm estado perto dos fiéis seguidores de Cristo. A vasta confederação do mal está ordenada contra todos que venceriam; mas Cristo quer que olhemos para as coisas que não se veem, para os exércitos do céu acampados ao redor de todos que amam a Deus, para livrá-los" (Ellen G. White, ^[O Desejado de Todas as Nações]({"style": {"text": {"typeface": "Omnes-Italic"}}), p. 240). Deus lhe deu esta promessa (e tantas outras), para reivindicar e orar por sua casa e família:
+
+> <callout>Salmos 16:8</callout>
+> "Tenho sempre o Senhor diante de mim; porque Ele está à minha direita, não serei abalado"

--- a/src/pt/aij/2026-01-bg/06/info.yml
+++ b/src/pt/aij/2026-01-bg/06/info.yml
@@ -1,0 +1,4 @@
+title: Deus Fez o Sol, a Lua e as Estrelas
+subtitle: Semana 6
+start_date: "01/02/2026"
+end_date: "07/02/2026"

--- a/src/pt/aij/2026-01-bg/07/01-story.md
+++ b/src/pt/aij/2026-01-bg/07/01-story.md
@@ -1,0 +1,34 @@
+---
+title: Deus Fez a Terra
+type: story
+audio:
+    src: https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-07.mp3
+---
+
+;;;
+^^^
+{"style":{"image":{"storyTextAlign": "top"}}}
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/07-00.png)
+{"style":{"text":{"color": "#159b48", "typeface": "Omnes-Bold", "align": "center"}, "block":{"backgroundColor": "#e1e1e1ad"}}}
+Deus Fez\
+^[Terra]({"style":{"text":{"color": "#006393", "typeface": "Omnes-BoldItalic"}}})
+^^^
+^^^
+{"style":{"image":{"storyTextAlign": "top"}}}
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/07-01.png)
+{"style":{"text":{"color": "#ffffff"}}}
+No início, antes de haver pandas no bambu ou cangurus pulando, Deus fez a terra. Tanto havia sido feito desde que Ele começou. Um . . . dois . . . três . . . quatro . . . dias (conte até quatro com os dedos) da Criação estavam feitos. Deus tinha mais para fazer enquanto criava um mundo bonito para você. Cada novo dia da Criação começava com o plano maravilhoso de Deus. A terra estava quase pronta; cada peça estava no seu lugar. Os dias 5, 6 e 7 (conte com os dedos) ainda estavam por vir. Deus sabia do que precisávamos antes que a Criação terminasse.
+^^^
+^^^
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/07-02.png)
+{"style":{"text":{"color": "#ffffff"}, "block":{"backgroundColor": "#181818ad"}}}
+A voz forte e bondosa de Deus ecoava sobre a água cada dia. No Dia 1 a terra se encheu com Sua luz, tornando tudo brilhante. No Dia 2 Ele fez o céu tão brilhante e azul. No Dia 3 havia muito para ver enquanto Deus reunia a terra seca e o mar. Ele fez as árvores altas e a grama, as plantas e as sementes. Deus criou mais no Dia 4: a luz do sol, a lua e as estrelas (conte cada dia com os dedos). Deus fez a terra para você e para mim. O ar cheirava a rosas e pinheiros. As colinas verdes onduladas eram pontilhadas com margaridas brancas. As gramas altas balançavam na brisa, e as ondas rolavam até a praia do mar. Sementes sopravam pelo ar, girando até o chão. O que seria encontrado onde cresciam, um salgueiro gracioso ou violetas amarelas? Os galhos das árvores subiam alto acima dos brotos tenros no jardim de cenouras e ervilhas. Tudo isso Deus viu (mão acima dos olhos; olhe ao redor), e era bom.
+^^^
+^^^
+{"style":{"image":{"storyTextAlign": "top"}}}
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/07-03.png)
+{"style":{"block": {"backgroundColor": "#ffffffad"},"text":{"color": "#000000"}}}
+Respire fundo (grande respiração) o ar e sinta o calor do sol. Isso lhe diz sobre o grande amor de Deus. Enquanto você se senta na grama e ela cócega nos seus dedos do pé (mexa os dedos do pé da criança), ria, e saiba que Deus a faz crescer. Deus fez tudo para você e para mim. Água para beber e comida deliciosa para comer. São maçãs crocantes ou nozes, tomates vermelhos, ou abacates verdes que são os melhores? O que você acha que Deus criaria depois? Deus ama você mais do que todas as estrelas do céu. A terra logo ganharia vida no Dia 5.\
+(Diga juntos) Obrigado, Deus, por fazer a terra para mim!
+^^^
+;;;

--- a/src/pt/aij/2026-01-bg/07/02-play.md
+++ b/src/pt/aij/2026-01-bg/07/02-play.md
@@ -1,0 +1,41 @@
+---
+title: Brinque Durante o Dia
+markdownTitle: '^[brinque]({"style": {"text": {"color": "#70a041"}}}) durante o dia'
+cover: https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/07-05.png
+titleBelowCover: true
+style:
+  segment:
+    title:
+      text:
+        typeface: Omnes-BlackItalic
+        align: center
+        color: "#cdcd47"
+---
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#70a041"}}}
+Crie
+
+Recorte estrelas de cores diferentes e decore-as com cola brilhante. Escreva uma oração simples de gratidão em cada estrela e pendure-as no teto acima da cama do seu filho.
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#70a041"}}}
+Explore
+
+Plante algumas mudas de vegetais ou ervas no jardim ou em um vaso. Enquanto você jardina juntos, mostre ao seu filho as raízes da planta. Converse sobre as coisas que uma planta precisa para crescer (sol, água, boa terra) e depois reguem a planta juntos. Agradeça a Deus pelas plantas incríveis que Ele fez para nós comermos!
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#70a041"}}}
+Faça
+
+Faça uma caixa sensorial de terra e céu. Faça duas porções de arroz colorido colocando dois copos em um recipiente vedável ou saco ziplock. Adicione várias gotas de corante alimentício azul e 1 colher de chá de vinagre em um, e corante alimentício verde com vinagre no outro. Bata bem. Espalhe em uma bandeja para secar completamente e depois coloque em uma caixa de armazenamento rasa. Sacuda cuidadosamente para fazer o céu e a terra. Adicione bolas de algodão para nuvens e coloque árvores e plantas na grama.
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#70a041"}}}
+Crie
+
+Use papel adesivo transparente para fazer uma arte de vitral da natureza. Recorte dois círculos do mesmo tamanho do papel adesivo. Vá para fora e colete quaisquer folhas, grama ou flores que puder encontrar. Retire o suporte de um dos círculos e pressione as folhas e flores o mais plano possível. Uma vez concluído, retire o outro círculo de papel adesivo e coloque por cima para cobri-lo. Pendure em uma janela como lembrete da incrível criação de Deus.
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#70a041"}}}
+Oração e Louvor
+
+Vá passear com seu filho para descobrir coisas que lembrem o que Deus fez nos Dias 1-4 da Criação. Encontre o maior número possível de itens de cores diferentes. Combine folhas, flores e pedras por sua cor, forma, tamanho ou suavidade/aspereza. Ao encontrar cada item, diga: "Obrigado, Deus, por fazer a terra para mim!"
+
+{"style": {"text": {"color": "#70a041", "typeface": "Omnes-Regular"}}
+**Versículo memorável semanal adicional**: "Assim diz o Senhor... 'Eu fiz a terra'" (Isaías 45:11, 12).

--- a/src/pt/aij/2026-01-bg/07/03-the-heart-of-the-matter.md
+++ b/src/pt/aij/2026-01-bg/07/03-the-heart-of-the-matter.md
@@ -1,0 +1,30 @@
+---
+title: O Coração da Questão
+markdownTitle: 'o ^[CORAÇÃO]({"style": {"text": {"color": "#EC3338"}}}) da ^[QUESTÃO]({"style": {"text": {"color": "#00A87D"}}})'
+subtitle: Para Pais
+markdownSubtitle: Para você, Pais
+style:
+  segment:
+    title:
+      text:
+        typeface: BaskervilleBT-Roman
+        align: center
+    subtitle:
+      text:
+        typeface: BaskervilleBT-Roman
+        align: center
+background: https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/07-04.png
+---
+
+"Mais, por favor" é uma frase frequentemente ouvida na casa de uma criança pequena. Tendo lido a história dez vezes ou jogado o mesmo jogo mais vezes do que você pode contar, você respira fundo e faz mais uma vez. O que há em fazer algo de novo e de novo que é tão atraente? Para nossas mentes adultas, essa repetição pode parecer entediante ou até irritante. A criança pequena, porém, prospera em poder antecipar o que vem a seguir. Seja sabendo o que está na próxima página do livro ou a próxima atividade na Escola Sabatina, o esperado é reconfortante e divertido!
+
+A repetição não apenas cria uma sensação de segurança para a criança, mas também é um bloco de construção importante para o desenvolvimento de novas habilidades. Repetir a mesma tarefa vez após vez fortalece as passagens neurais para o aprendizado. À medida que progridem e dominam com sucesso uma habilidade, eles desenvolvem a confiança e fortalecem as conexões necessárias para aplicar essa habilidade de uma nova forma.
+
+Incentive-os a expandir seu aprendizado além da repetição de ler o mesmo livro de novo e de novo. Use o tema de sua história favorita para explorar e expressar suas próprias ideias. Envolva seus sentidos e imaginações no processo enquanto incentiva a auto-reflexão através de perguntas abertas como: "O que você acha que sentiu?" "Eu me pergunto o que eles farão a seguir?" ou "O que você acha que cheirava?"
+
+Observe enquanto seu filho aprende e cresce através da repetição. Enquanto repetem as mesmas ações de novo e de novo, você os verá desenvolver coordenação e controle. Através da repetição eles também descobrirão o sucesso à medida que desenvolvem perseverança. Tenha coragem sabendo que Deus também nos observa com amor e paciência enquanto muitas vezes exigimos repetição para aprender a confiar Nele. É em saber que podemos fazer de novo que encontramos uma resiliência não intimidada por uma queda, mas sim fortalecida na oportunidade de se levantar e dizer: "Mais, por favor."
+
+"O que nos aventuramos a fazer uma vez, somos mais propensos a fazer de novo. Hábitos de sobriedade, de autocontrole, de economia, de aplicação diligente, de conversa sensata, de paciência e verdadeira cortesia, não são ganhos sem vigilância diligente e cuidadosa sobre si mesmo... Esforços perseverantes serão necessários se as graças cristãs forem alguma vez aperfeiçoadas em nossas vidas" (Ellen G. White, ^[Testemunhos para a Igreja]({"style": {"text": {"typeface": "Omnes-Italic"}}), vol. 4, p. 452).
+
+> <callout>Gálatas 6:9</callout>
+> "E não nos cansemos de fazer o bem, porque a seu tempo ceifaremos, se não desfalecermos"

--- a/src/pt/aij/2026-01-bg/07/info.yml
+++ b/src/pt/aij/2026-01-bg/07/info.yml
@@ -1,0 +1,4 @@
+title: Deus Fez a Terra
+subtitle: Semana 7
+start_date: "08/02/2026"
+end_date: "14/02/2026"

--- a/src/pt/aij/2026-01-bg/08/01-story.md
+++ b/src/pt/aij/2026-01-bg/08/01-story.md
@@ -1,0 +1,33 @@
+---
+title: Deus Fez os Peixes do Mar
+type: story
+audio:
+    src: https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-08.mp3
+---
+
+;;;
+^^^
+{"style":{"image":{"storyTextAlign": "top"}}}
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/08-00.png)
+{"style":{"text":{"color": "#fbe000", "typeface": "Omnes-Bold", "align": "center"}, "block":{"backgroundColor": "#7aadc0ad"}}}
+Deus Fez os\
+^[Peixes do Mar]({"style":{"text":{"color": "#def2f8", "typeface": "Omnes-BoldItalic"}}})
+^^^
+^^^
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/08-01.png)
+{"style":{"text":{"color": "#ffffff"}, "block":{"backgroundColor": "#181818ad"}}}
+No início, antes de haver leões em uma alcateia ou vagalumes brilhantes, havia Deus. Era o Dia 5 (cinco dedos), e Deus estava pronto para fazer a terra ganhar vida. Em apenas quatro dias muito tinha sido feito. Havia coqueiros e um grande mar. Deus tinha feito o sol para brilhar forte e a lua para a noite. A terra era bonita e verde; mas ainda, nenhuma vida podia ser vista. As estrelas se apagavam uma por uma (movimento de piscar com as mãos), enquanto o sol subia. O orvalho brilhava na grama enquanto as palmeiras balançavam na brisa. O ar cheirava doce com jasmim e morangos. As ondas do mar rolavam sobre a areia. A terra estava pronta para o que Deus planejou. A vida estava prestes a chegar no Dia 5 (cinco dedos). Enquanto o sol aquecia o dia, um golfinho saltou na baía. Um cardume de peixes prateados brilhava na luz. Raias majestosas deslizavam ao longo do recife, e uma baleia cinza espirrava (bata as mãos juntas, depois para cima), depois mergulhou fundo. Tartarugas marinhas cavalgavam as correntes enquanto águas-vivas flutuavam na maré. Havia ainda mais que Deus faria no Dia 5. Deus viu (mão acima dos olhos; olhe ao redor) tudo o que Ele tinha feito, e era bom.
+^^^
+^^^
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/08-02.png)
+{"style":{"text":{"color": "#ffffff"}, "block":{"backgroundColor": "#181818ad"}}}
+A voz forte e bondosa de Deus ecoava sobre as colinas. Enquanto Ele falava, o mar ganhou vida com criaturas de todas as cores e tamanhos. Peixes brilhantes azuis e amarelos começaram a nadar para lá e para cá (mão nadando como um peixe), e um polvo rastejava lá embaixo. Uma estrela do mar encontrou seu lugar nas pedras enquanto peixes-boi roíam talos folhosos. A água estava viva com as criaturas do mar que Deus fez no Dia 5.
+^^^
+^^^
+{"style":{"image":{"storyTextAlign": "top"}}}
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/08-03.png)
+{"style":{"block": {"backgroundColor": "#ffffffad"},"text":{"color": "#000000"}}}
+Deus fez tudo isso para você e para mim! Você já esteve no mar? Há conchas para coletar e pedras bonitas de muitas cores. Quando você anda na areia, você gosta da sensação nos seus dedos do pé? Você consegue encontrar os caranguejos que andam de lado ou as anêmonas esperando pela maré? Observe de perto para ver uma baleia espirrar ou um golfinho saltar. Deus fez toda essa maravilha do mar para você e para mim. Ele tinha mais para trazer à vida no Dia 5. O que você acha que vai chegar a seguir?\
+(Diga juntos) Obrigado, Deus, por fazer todos os peixes!
+^^^
+;;;

--- a/src/pt/aij/2026-01-bg/08/02-play.md
+++ b/src/pt/aij/2026-01-bg/08/02-play.md
@@ -1,0 +1,42 @@
+---
+title: Brinque Durante o Dia
+markdownTitle: '^[brinque]({"style": {"text": {"color": "#fbac50"}}}) durante o dia'
+cover: https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/08-05.png
+titleBelowCover: true
+style:
+  segment:
+    title:
+      text:
+        typeface: Omnes-BlackItalic
+        align: center
+        color: "#834f9a"
+---
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#834f9a"}}}
+Crie
+
+Ajude seu filho a começar o Dia 5 do Livro da Criação. Pinte a metade inferior do papel de azul para o oceano. Coloque cola bem na parte inferior da página e espalhe areia por cima para criar o fundo do oceano. Use peixes de espuma adesiva para criar um cardume de peixes e outras criaturas marinhas. Mantenha a parte superior da página em branco para os pássaros na próxima semana.
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#834f9a"}}}
+Explore
+
+Faça uma caixa sensorial de oceano. Use peixes de plástico e animais do oceano, conchas, copinhos e conchas, e areia. Cubra com água e adicione duas gotas de corante alimentício azul. Deixe seu filho explorar puxar e despejar água, pegando os itens do oceano e nomeando-os.
+
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#834f9a"}}}
+Aprenda
+
+Pesquise diferentes tipos de vida marinha juntos. Visite um aquário local ou encontre um tour online. Pesquise na biblioteca local por livros sobre diferentes animais que vivem no oceano. Recorte algumas fotos de criaturas marinhas incríveis e escreva alguns fatos legais ao lado delas (por exemplo, Há 40 tipos diferentes de cavalos-marinhos, golfinhos têm dois estômagos, tartarugas não têm dentes, etc.).
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#834f9a"}}}
+Crie
+
+Crie uma garrafa "Eu vejo no Oceano". Encha uma garrafa de plástico vazia com seixos de aquário azul, pequenas conchas e animais do oceano de plástico. Nomeie os animais do oceano enquanto você os coloca. Encha com água e corante alimentício azul e sele a tampa. Agite suavemente para esconder os itens nos seixos. Nomeie um animal para seu filho encontrar.
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#834f9a"}}}
+Ore
+
+Vá ao mar, rio ou lago. Procure pedras bonitas ou conchas. Compartilhe com seu filho como as pedras e conchas ajudam a fazer lares para muitos animais que vivem na água. Deus cuida de todos os Seus animais. Deus cuida de você também! Orem juntos e agradeçam a Deus por fazer os animais do mar e por cuidar deles. Traga uma concha ou pedra para casa para lembrá-los do cuidado de Deus por toda a Sua criação.
+
+{"style": {"text": {"color": "#834f9a", "typeface": "Omnes-Regular"}}
+**Versículo memorável semanal adicional**: "Assim Deus criou os grandes animais marinhos" (Gênesis 1:21).

--- a/src/pt/aij/2026-01-bg/08/03-the-heart-of-the-matter.md
+++ b/src/pt/aij/2026-01-bg/08/03-the-heart-of-the-matter.md
@@ -1,0 +1,32 @@
+---
+title: O Coração da Questão
+markdownTitle: 'o ^[CORAÇÃO]({"style": {"text": {"color": "#904496"}}}) da ^[QUESTÃO]({"style": {"text": {"color": "#008AC7"}}})'
+subtitle: Para Pais
+markdownSubtitle: Para você, Pais
+style:
+  segment:
+    title:
+      text:
+        typeface: BaskervilleBT-Roman
+        align: center
+    subtitle:
+      text:
+        typeface: BaskervilleBT-Roman
+        align: center
+background: https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/08-04.png
+---
+
+Animais alados e criaturas do mar foram os primeiros dos animais que Deus faria. Ele os abençoou para ir adiante e multiplicar. Tudo era bom, e nada era destrutivo. Que incrível é testemunhar a bondade e criatividade de Deus! Mas depois que Adão e Eva pecaram, cada espécie desenvolveu uma capacidade única para sua sobrevivência. O peixe-lanterna usa uma luz para atrair seu café da manhã, enquanto a avestruz pode correr até 69 km/h usando suas asas como lemes para virar rapidamente e evitar predadores. No céu e na terra feitos novos, porém, não haverá dor, sofrimento ou morte, assim como Deus tinha feito no início.
+
+A imitação é um método de sobrevivência usado por muitos pássaros e peixes. Para algumas espécies a imitação ocorre para proteger-se de predadores, seja para se esconder ou se encaixar em um grupo. O papagaio usa imitação vocal para se encaixar em um bando para proteção.
+
+Algumas espécies usam imitação para ajudá-los a capturar uma refeição usando camuflagem para se esconder e esperar pela presa. O peixe-blenny dentes-de-sabre imitará a coloração e o comportamento do peixe-limão, um peixe limpador. Os peixes virão para serem limpos pelo peixe-limão só para descobrir que foram enganados e mordidos por um blenny. É apenas através de atenção cuidadosa para sinais reveladores e familiaridade com o original e o imitador que o engano pode ser evitado. Os jovens são particularmente vulneráveis a serem enganados pela coloração e comportamento de um blenny, pois ainda não aprenderam como discernir o ardil enganoso do imitador.
+
+Assim como o peixe-blenny dentes-de-sabre, Satanás usará qualquer método ao seu dispor para atrair e enganar vítimas para sua armadilha. Aprender a estar de guarda para os métodos do mestre imitador, Satanás, requer conhecer o único e verdadeiro Deus. É através de um relacionamento pessoal com Deus que podemos discernir os métodos do grande enganador.
+
+Tempo a sós com Deus gasto em Sua Palavra e em oração o aproximará do conhecimento dos caminhos do Libertador e revelará a astúcia do enganador. Quanto mais conhecemos a Deus, menos suscetíveis somos a sermos enganados pela imitação de Satanás. "Jesus viveu em dependência de Deus e comunhão com Ele... A vida de Jesus foi uma vida de confiança constante, sustentada por comunhão contínua" (Ellen G. White, ^[Educação]({"style": {"text": {"typeface": "Omnes-Italic"}}), p. 80).
+
+Em conhecer a verdade de que Deus é amoroso e misericordioso, somos protegidos da armadilha de Satanás. Há muitas lições a serem ganhas observando a criação de Deus; a maior delas é Seu amor e cuidado. Assim como uma ave mãe protege seus filhotes sob suas asas, Deus o cobrirá com Sua proteção amorosa.
+
+> <callout>Salmos 91:3, 4</callout>
+> "Certamente Ele te livrará do laço do passarinheiro e da perniciosa peste. Ele te cobrirá com as suas penas, e debaixo das suas asas estarás seguro; a sua verdade é pavês e escudo"

--- a/src/pt/aij/2026-01-bg/08/info.yml
+++ b/src/pt/aij/2026-01-bg/08/info.yml
@@ -1,0 +1,4 @@
+title: Deus Fez os Peixes do Mar
+subtitle: Semana 8
+start_date: "15/02/2026"
+end_date: "21/02/2026"

--- a/src/pt/aij/2026-01-bg/09/01-story.md
+++ b/src/pt/aij/2026-01-bg/09/01-story.md
@@ -1,0 +1,34 @@
+---
+title: Deus Fez as Aves do Céu
+type: story
+audio:
+    src: https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-09.mp3
+---
+
+;;;
+^^^
+{"style":{"image":{"storyTextAlign": "top"}}}
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/09-00.png)
+{"style":{"text":{"color": "#2a418f", "typeface": "Omnes-Bold", "align": "center"}, "block":{"backgroundColor": "#e1e1e1ad"}}}
+Deus Fez as\
+^[Aves]({"style":{"text":{"color": "#d5428b", "typeface": "Omnes-BoldItalic"}}}) do ^[Céu]({"style":{"text":{"color": "#d5428b", "typeface": "Omnes-BoldItalic"}}})
+^^^
+^^^
+{"style":{"image":{"storyTextAlign": "top"}}}
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/09-01.png)
+{"style":{"text":{"color": "#ffffff"}, "block":{"backgroundColor": "#7aadc0ad"}}}
+No início, antes de haver focas que brincam e deslizam ou lindas borboletas, havia Deus. O Dia 5 (cinco dedos) tinha começado, e a terra estava ganhando vida. Deus tinha enchido o mar com criaturas grandes e pequenas. Havia peixes para nadar nos rios e golfinhos para saltar no mar. Havia estrelas do mar nas pedras e polvos no fundo. Deus tinha enchido a água com vida, mas ainda havia mais para chegar no Dia 5. Enquanto o sol subia alto acima, a nova criação de Deus explorava seu lar no mar abaixo. Um golfinho brincalhão saltava e mergulhava. Uma baleia cinza soprava de seu espiráculo (bata as mãos juntas e para cima), e um caranguejo corria. Um peixe-palhaço nadava entre recifes de corais coloridos. A luz brilhava através do mar, estourando de vida. Deus tinha acabado de começar a trazer a terra à vida no Dia 5 (cinco dedos). O que viria a seguir para nós vermos?
+^^^
+^^^
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/09-02.png)
+{"style":{"text":{"color": "#ffffff"}, "block":{"backgroundColor": "#181818ad"}}}
+A voz forte e bondosa de Deus ecoava sobre as colinas. Enquanto Ele falava, o ar ganhava vida com pássaros de todas as cores e tamanhos, beija-flores minúsculos e avestruzes gigantes (mostre o tamanho com as mãos), flamingos rosa e tentilhões roxos. Pássaros chilreavam e conversavam nas árvores, e pelicanos voavam acima do mar. Um casal de calhandras amarelas tinha uma canção linda para cantar, e gansos voavam alto acima em um V. A terra e o céu estavam vivos com os pássaros que Deus fez no Dia 5. Enquanto o sol se punha baixo, uma coruja chamava, "Hoo, hoo." Um gavião voava de um pinheiro alto. Uma mamãe pata cambaleava ao longo da praia. "Quack, quack," ela chamava para seus patinhos em fila. Papagaios conversavam em uma bananeira enquanto o Dia 5 chegava ao fim. Deus viu (mão acima dos olhos; olhe ao redor) tudo o que Ele tinha feito, e era bom.
+^^^
+^^^
+{"style":{"image":{"storyTextAlign": "top"}}}
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/09-03.png)
+{"style":{"block": {"backgroundColor": "#ffffffad"},"text":{"color": "#000000"}}}
+Escute (mão no ouvido); você ouve os pássaros cantando? Eles estão felizes enquanto cantam sobre o amor de Deus. Há vermelhos, e azuis, e amarelos também. Deus fez cada um com uma canção especial para você. Alguns pássaros voam bem alto, como uma águia, e outros correm no chão, como uma ema. Deus cuida de cada um que Ele fez, e ainda mais, Ele cuida de você. Deus estava animado com o que viria a seguir. O que você acha que está por vir no Dia 6 (seis dedos)?\
+(Diga juntos) Obrigado, Deus, por fazer os pássaros!
+^^^
+;;;

--- a/src/pt/aij/2026-01-bg/09/02-play.md
+++ b/src/pt/aij/2026-01-bg/09/02-play.md
@@ -1,0 +1,41 @@
+---
+title: Brinque Durante o Dia
+markdownTitle: '^[brinque]({"style": {"text": {"color": "#67a0d6"}}}) durante o dia'
+cover: https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/09-05.png
+titleBelowCover: true
+style:
+  segment:
+    title:
+      text:
+        typeface: Omnes-BlackItalic
+        align: center
+        color: "#4969b2"
+---
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#4969b2"}}}
+Crie
+
+Ajude seu filho a terminar a página do Dia 5 no Livro da Criação. Recorte pequenos círculos de papel de cores diferentes e pequenos bicos triangulares amarelos. Faça seu filho colar os círculos. Cole olhos móveis e bicos. Cole penas artesanais para as asas. Escreva na parte inferior da página: "No Dia 5 Deus criou os peixes no mar e as aves do ar."
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#4969b2"}}}
+Explore
+
+Compartilhe como os pássaros constroem ninhos para manter seus filhotes seguros. Vá para fora e use gravetos, folhas e casca para construir um ninho. Finjam ser pássaros e voem ao redor procurando um lugar seguro para seus filhotes. "Aterrissem" em seu "ninho" e finjam cuidar de seus filhotes.
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#4969b2"}}}
+Aprenda
+
+Mostre ao seu filho fotos de pássaros com penas da cauda grandes e coloridas, como pavões e perus. Desenvolva coordenação e habilidades manuais fazendo uma plumagem de cauda empurrando penas artesanais nos buracos de um escorredor colocado de cabeça para baixo.
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#4969b2"}}}
+Cuide
+
+Faça um comedouro de sementes para pássaros. Misture duas colheres de óleo de coco com sementes para pássaros. Adicione manteiga de amendoim ou manteiga de girassol. Endureça na geladeira por 30 minutos, depois forme em um cortador de biscoitos ou forma para muffins. Faça um furo no topo para um laço de corda. Coloque no freezer por duas horas para endurecer. Retire, e pendure fora. Compartilhe como Deus ama e cuida do seu filho, assim como Ele cuida dos pássaros.
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#4969b2"}}}
+Oração e Louvor
+
+Sente-se em silêncio com seu filho fora e ouça os pássaros cantando. Procure os pássaros cujas canções você ouve e converse sobre suas diferentes cores. Compartilhe o versículo bíblico Mateus 6:26 sobre Deus cuidar das aves do céu, e o quanto Ele cuida de você. Façam uma canção juntos para agradecer a Deus pelos pássaros e por cuidar de nós também.
+
+{"style": {"text": {"color": "#4969b2", "typeface": "Omnes-Regular"}}
+**Versículo memorável semanal adicional**: "Assim Deus criou... toda ave que voa" (Gênesis 1:21).

--- a/src/pt/aij/2026-01-bg/09/03-the-heart-of-the-matter.md
+++ b/src/pt/aij/2026-01-bg/09/03-the-heart-of-the-matter.md
@@ -1,0 +1,27 @@
+---
+title: O Coração da Questão
+markdownTitle: 'o ^[CORAÇÃO]({"style": {"text": {"color": "#D8316E"}}}) da ^[QUESTÃO]({"style": {"text": {"color": "#00B4C0"}}})'
+subtitle: Para Pais
+markdownSubtitle: Para você, Pais
+style:
+  segment:
+    title:
+      text:
+        typeface: BaskervilleBT-Roman
+        align: center
+    subtitle:
+      text:
+        typeface: BaskervilleBT-Roman
+        align: center
+background: https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/09-04.png
+---
+
+Você já parou e observou um pássaro grande planar, ficando cada vez mais alto sem aparentemente nenhum esforço? O condor dos Andes, um dos pássaros voadores mais pesados do mundo, pode voar até 21.325 pés (6.500 metros). Isso é mais alto que o Kilimanjaro, o pico mais alto da África, ou o Monte Denali, o pico mais alto da América do Norte.
+
+Como tais pássaros grandes voam tão alto? É chamado de planagem térmica — bolsos de ar quente subindo que os pássaros usarão para ir mais e mais alto. Este é o mesmo ar quente subindo que pode causar turbulência ao voar em um avião. Observar um pássaro grande planar tão pacificamente neste ar turbulento é uma maravilha. Cientistas estudam este fenômeno para aprender mais sobre melhorar o voo humano. Parece que os pássaros usam um método de "ir com o fluxo". Isso significa que eles não se preocupam se o ar está levando-os na direção que querem ir, mas permitem que o ar os leve em círculos para alcançar altitudes mais altas, onde o vento é mais suave e rápido. Eles então deslizam enquanto procuram por comida, perdendo altitude até pegar outra térmica para cima.
+
+Ao se encontrar em meio a tempos difíceis, sua tendência é tentar controlar sua situação? Pode ser difícil parar de se preocupar e se acomodar para o passeio, confiando que Deus se preocupa com cada uma de suas necessidades e tem um plano para o bem em sua vida. Esses pássaros massivos confiam no fluxo de ar para carregá-los mesmo quando parece que estão indo em círculos sem direção. Assim como a águia que plana no ar, você também pode confiar que Deus o carregará através (veja Isaías 40:31). "Expõe teu caso ao Senhor, e quaisquer que sejam tuas ansiedades e provações, teu espírito será fortalecido para a paciência... Confia em Deus como teu Ajudador presente, que sobrepujará todas as coisas como Aquele que sabe melhor" (Ellen G. White, ^[Este Dia Com Deus]({"style": {"text": {"typeface": "Omnes-Italic"}}), p. 82).
+
+A criação de Deus é uma bela demonstração de Seu amor e um lembrete de Sua fidelidade. Quando tempos de tempestade se aproximam, os pássaros encontram abrigo do vento e da chuva em arbustos densos ou próximos aos troncos das árvores. Quando a tempestade passa, ouça a canção dos pássaros. Mesmo enquanto ainda está chovendo, eles cantarão.
+
+Deus prometeu ser nosso abrigo na tempestade. Enquanto você confia Nele também descobrirá que pode cantar mesmo nos tempos turbulentos e tempestuosos. Quando você não sabe para qual direção virar ou onde esperar a chuva passar, foque nas promessas de Deus. Observe as Suas provisões para ajudá-lo a planar.

--- a/src/pt/aij/2026-01-bg/09/info.yml
+++ b/src/pt/aij/2026-01-bg/09/info.yml
@@ -1,0 +1,4 @@
+title: Deus Fez as Aves do Céu
+subtitle: Semana 9
+start_date: "22/02/2026"
+end_date: "28/02/2026"

--- a/src/pt/aij/2026-01-bg/10/01-story.md
+++ b/src/pt/aij/2026-01-bg/10/01-story.md
@@ -1,0 +1,33 @@
+---
+title: Deus Fez os Animais
+type: story
+audio:
+    src: https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-10.mp3
+---
+
+;;;
+^^^
+{"style":{"image":{"storyTextAlign": "top"}}}
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/10-00.png)
+{"style":{"text":{"color": "#ffe100", "typeface": "Omnes-Bold", "align": "center"}, "block":{"backgroundColor": "#00000066"}}}
+Deus Fez os\
+^[Animais]({"style":{"text":{"color": "#fffbca", "typeface": "Omnes-BoldItalic"}}})
+^^^
+^^^
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/10-01.png)
+{"style":{"text":{"color": "#ffffff"}, "block":{"backgroundColor": "#00000066"}}}
+No princípio, antes de haver pintinhos ou grilos barulhentos, havia Deus. Era o dia 6 (seis dedos), e Deus estava prestes a fazer algo grande! No dia 5 a terra tinha ganho vida. Deus tinha feito pássaros que voavam pelo céu (levantar a mão), e peixes que nadavam e mergulhavam (empurrar as mãos para baixo). O sol brilhava forte, e as estrelas brilhavam à noite, mas nem um leão ou cordeiro estava à vista. Quando o sol nasceu, os pássaros cantaram ao despertar. Uma brisa suave soprava através dos juncos altos e espalhava sementes. O cheiro fresco de manga e pera flutuava pelo ar. O rio corria para um lago onde peixes dourados nadavam (mão nadando) em grupo. Deus tinha um plano muito maior do que tudo isso. Ele estava pronto para começar o dia 6 (seis dedos).
+^^^
+^^^
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/10-02.png)
+{"style":{"text":{"color": "#ffffff"}, "block":{"backgroundColor": "#00000066"}}}
+A forte e bondosa voz de Deus ecoou pelas colinas: "Que a terra se encha de animais" (Gênesis 1:24, NVI). Enquanto Ele falava, uma manada de elefantes apareceu, e debaixo de uma rocha correu (dedos correndo) um lagarto manchado. Um coelho mexeu o nariz enquanto cães-da-pradaria saltaram de seus buracos. Um urso negro desceu a colina pesadamente, comendo frutas silvestres. Deus fez tantos animais, grandes e pequenos. Tudo isso Deus fez no dia 6. Enquanto o sol subia alto no céu, um ouriço observou um guepardo correndo. Uma vaca mugiu feliz, mastigando grama, enquanto uma cabra brincalhona passou correndo. Macacos balançavam nos galhos acima, enquanto uma girafa alta mastigava uma folha. Um leão rugiu de alegria com a vista. Ainda havia mais a ser feito no dia 6. Deus viu (mão acima dos olhos; olhar ao redor) tudo o que tinha feito, e era bom.
+^^^
+^^^
+{"style":{"image":{"storyTextAlign": "top"}}}
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/10-03.png)
+{"style":{"block": {"backgroundColor": "#ffffffad"},"text":{"color": "#000000"}}}
+Deus fez todos os animais grandes (mãos abertas) e pequenos! (Mãos fechadas.) Você conhece um animal que vive na fazenda? Na selva . . . no lago . . . no mato . . . na neve? Há animais que rugem, e outros que latem, alguns que trombetam ou mexem o nariz, uns que se arrastam, e alguns que pulam (faça cada um enquanto lê). Tantos animais, minúsculos e altos; Deus fez todos eles. Ele ainda não havia terminado; o melhor ainda estava por vir antes do sol se pôr.\
+(Diga juntos) Obrigado, Deus, por fazer os animais!
+^^^
+;;;

--- a/src/pt/aij/2026-01-bg/10/02-play.md
+++ b/src/pt/aij/2026-01-bg/10/02-play.md
@@ -1,0 +1,51 @@
+---
+title: Brinque Durante o Dia
+markdownTitle: '^[Brinque]({"style": {"text": {"color": "#efb81c"}}}) durante o dia'
+cover: https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/10-05.png
+titleBelowCover: true
+style:
+  segment:
+    title:
+      text:
+        typeface: Omnes-BlackItalic
+        align: center
+        color: "#94aa37"
+---
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#94aa37"}}}
+Crie
+
+Ajude seu filho a fazer a página do dia 6 do Livro da Criação. Use cartão azul para o céu, grama artificial ou papel verde com muitos cortes para a grama, bolas de algodão para nuvens, e papel colorido para flores. Use adesivos de espuma ou feltro para animais ou recorte algumas imagens de animais para usar para criar a cena. Deixe espaço para adicionar Adão e Eva na próxima semana.
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#94aa37"}}}
+Cuide
+
+Deixe seu filho ajudar a cuidar de animais de estimação. Ensine-o a usar mãos macias e gentis ao brincar ou acariciar. Ao se aproximar de animais de estimação de outros, demonstre calma e respeito e sempre peça permissão antes de se aproximar ou acariciar. Se você não tem animais de estimação em casa, finja cuidar de alguns animais de pelúcia. Converse sobre as coisas que os animais precisam para ter uma vida feliz e saudável.
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#94aa37"}}}
+Explore
+
+Use massa de modelar e animais de plástico para criar diferentes pegadas na massa de modelar. Deixe seu filho adivinhar o animal que deixou as pegadas. Deixe-o criar pegadas com seu animal favorito. Agradeça a Deus por todos os animais únicos que Ele fez para nós apreciarmos.
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#94aa37"}}}
+Aprenda
+
+Brinque de um jogo de classificação de animais. Faça dois grupos usando um círculo de corda ou duas folhas de papel. Reúna animais de plástico ou animais de pelúcia. Cante "Animais, Animais," e escolha um. Coloque o animal no círculo correto. A classificação pode incluir animais grandes/pequenos, animais com duas patas e quatro patas, etc.
+
+{"style":{"block": {"padding": {"start": "xl"}}}}
+**Animais, Animais**\
+Animais, animais, Jesus fez\
+os animais!\
+Animais grandes, animais minúsculos (fique em pé, agache-se pequeno)\
+Animais, animais, Jesus fez \
+os animais!\
+Aqui está um animal que eu conheço . . .\
+um (grande ou minúsculo) _____.
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#94aa37"}}}
+Ore
+
+Brinque de "Quem sou eu?" Dê ao seu filho dicas para adivinhar qual animal você está pensando
+
+{"style": {"text": {"color": "#94aa37", "typeface": "Omnes-Regular"}}
+**Versículo para memorizar semanal**: "Deus disse: 'Que a terra produza seres viventes . . . '" (Gênesis 1:24).

--- a/src/pt/aij/2026-01-bg/10/03-the-heart-of-the-matter.md
+++ b/src/pt/aij/2026-01-bg/10/03-the-heart-of-the-matter.md
@@ -1,0 +1,31 @@
+---
+title: O Coração da Questão
+markdownTitle: 'o ^[CORAÇÃO]({"style": {"text": {"color": "#008A5D"}}}) da ^[QUESTÃO]({"style": {"text": {"color": "#F58D38"}}})'
+subtitle: Para Pais
+markdownSubtitle: Para você, Pais
+style:
+  segment:
+    title:
+      text:
+        typeface: BaskervilleBT-Roman
+        align: center
+    subtitle:
+      text:
+        typeface: BaskervilleBT-Roman
+        align: center
+background: https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/10-04.png
+---
+
+Que dia emocionante deve ter sido o sexto dia da Criação! Deus criou animais de todas as formas, tamanhos e cores imagináveis. Ao passar tempo na natureza, faça uma pausa por um momento e considere a incrível criatividade de Deus. É no design incrível dos animais que podemos ver a natureza divina de Deus.
+
+Deus não projetou um mundo monocromático, mas sim um de beleza rica e variedade. Cada espécie animal tem suas próprias características únicas. As belas manchas no leopardo-das-neves ou a notável coloração da borboleta cauda-de-andorinha esmeralda demonstram o desejo de Deus não apenas de criar para função, mas também de criar um mundo de maravilha e beleza.
+
+Deus criou os animais como um presente para nós apreciarmos e cuidarmos. Eles foram originalmente projetados como ajudantes e companheiros. Embora muito tenha mudado desde que o pecado entrou no mundo, ainda podemos vislumbrar o design original de Deus. Quando tomamos o tempo de notar as muitas coisas incríveis na natureza, aprendemos mais sobre Deus e Seu amor e cuidado por nós.
+
+Os animais proporcionam uma apreciação por todas as criaturas de Deus e uma oportunidade maravilhosa de ensinar seu filho sobre bondade e cuidado pelos outros. As crianças podem aprender muito sobre compaixão e ser gentis e respeitosas com os animais, seja na natureza selvagem ou um animal de estimação em casa. Ao caminhar, esteja atento às criaturas de Deus. Ensine seu filho a observar com maravilha e apreciar sem perturbar seus padrões naturais. Tire o tempo para observar uma lagarta atravessar um caminho e maravilhar-se com o jeito engraçado como ela se move, ou observar uma trilha de formigas ocupadas com seu trabalho. O amor e o cuidado de Deus por até mesmo a mais minúscula de Suas criaturas é grande, mas é apenas uma reflexão pálida do maior amor que Ele tem por cada um de nós.
+
+> <callout>Job 12:9, 10</callout>
+> "Quem, entre todos esses, não sabe que a mão do Senhor fez isso? Na mão dele está a vida de todo ser vivente, e o fôlego de toda a humanidade."
+
+> <callout>Ellen G. White, Educação, pp. 99, 100</callout>
+> "Sobre todas as coisas criadas vê-se o caráter da Divindade. A natureza testifica de Deus. . . . A unidade do homem com a natureza e com Deus, o domínio universal da lei, os resultados da transgressão, não podem deixar de impressionar a mente e moldar o caráter"

--- a/src/pt/aij/2026-01-bg/10/info.yml
+++ b/src/pt/aij/2026-01-bg/10/info.yml
@@ -1,0 +1,4 @@
+title: Deus Fez os Animais
+subtitle: Semana 10
+start_date: "01/03/2026"
+end_date: "07/03/2026"

--- a/src/pt/aij/2026-01-bg/11/01-story.md
+++ b/src/pt/aij/2026-01-bg/11/01-story.md
@@ -1,0 +1,32 @@
+---
+title: Deus Fez Adão e Eva
+type: story
+audio:
+    src: https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-11.mp3
+---
+
+;;;
+^^^
+{"style":{"image":{"storyTextAlign": "top"}}}
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/11-00.png)
+{"style":{"text":{"color": "#fff200", "typeface": "Omnes-Bold", "align": "center"}, "block":{"backgroundColor": "#00000066"}}}
+Deus Fez\
+^[Adão]({"style":{"text":{"color": "#ffffff", "typeface": "Omnes-BoldItalic"}}}) e ^[Eva]({"style":{"text":{"color": "#ffffff", "typeface": "Omnes-BoldItalic"}}})
+^^^
+^^^
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/11-01.png)
+{"style":{"text":{"color": "#ffffff"}, "block":{"backgroundColor": "#00000066"}}}
+No princípio, antes de haver rinocerontes ou coelhos, havia Deus. Muito tinha sido feito no início do dia 6. Deus fez grandes elefantes e girafas altas, cordeiros doces e cavalos fortes. A terra estava cheia de sons de pássaros cantando e cheiro de flores desabrochando. Deus ainda não havia terminado o dia 6 (seis dedos). O mar brilhava forte no sol. Macacos balançavam nas vinhas, mas não havia ninguém para observar (apontar para os olhos) eles subirem. Pássaros cantavam, mas não havia ninguém para ouvir (apontar para o ouvido) sua canção. Folhas dançavam na brisa, mas não havia ninguém para girar (girar a criança) junto. Flores desabrochavam, mas não havia ninguém para sentir (cheirar) seu perfume. Golfinhos brincavam, mas não havia ninguém para sentir o spray da água (mover os dedos). Deus sabia que a Criação ainda não estava totalmente completa; o melhor estava por vir.
+^^^
+^^^
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/11-02.png)
+{"style":{"text":{"color": "#184c07"}, "block":{"backgroundColor": "#e1e1e1ad"}}}
+Deus estava animado! Ele reuniu um pouco de terra na forma de um homem. Deus fez um homem que se parecia com Ele. Ele soprou (soprar) no homem. Quando o homem abriu os olhos, Ele viu Deus olhando para ele, sorrindo com amor! Deus chamou o homem de Adão. Deus trouxe cada animal para Adão nomear. Nenhum deles se parecia com Adão. Deus sabia que Adão precisava de uma família própria. Alguém para ser seu amigo; alguém para ser sua esposa. Então Deus criou uma mulher chamada Eva. Deus casou-os nesse mesmo dia. Quando o sol se punha baixo, Adão e Eva caminhavam e conversavam com Deus. Deus viu (mão acima dos olhos; olhar ao redor) tudo o que Ele tinha feito, e era muito bom.
+^^^
+^^^
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/11-03.png)
+{"style":{"block": {"backgroundColor": "#ffffffad"},"text":{"color": "#000000"}}}
+Deus fez Adão e Eva, a primeira família, no dia 6 (seis dedos). Eles se amavam e trabalhavam juntos no belo jardim que Deus tinha feito. Eram pessoas como você e eu. Eram amigos de Deus e conversavam com Ele todos os dias. Deus também é seu amigo. Ele o ama muito! (Abraçar a criança.) Ele gosta de ouvir você orar e conversar sobre seu dia. Ele ouve cada canção que você canta e cada "Obrigado" que você traz.\
+(Diga juntos) Obrigado, Deus, por fazer Adão e Eva!
+^^^
+;;;

--- a/src/pt/aij/2026-01-bg/11/02-play.md
+++ b/src/pt/aij/2026-01-bg/11/02-play.md
@@ -1,0 +1,41 @@
+---
+title: Brinque Durante o Dia
+markdownTitle: '^[Brinque]({"style": {"text": {"color": "#7ec3e9"}}}) durante o dia'
+cover: https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/11-05.png
+titleBelowCover: true
+style:
+  segment:
+    title:
+      text:
+        typeface: Omnes-BlackItalic
+        align: center
+        color: "#7ebf42"
+---
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#7ebf42"}}}
+Crie
+
+Ajude seu filho a criar uma imagem de Adão e Eva para adicionar à página do dia 6 no Livro da Criação. Recorte duas pessoas e adicione características faciais. Use olhos móveis e lã para o cabelo. Escreva abaixo da imagem: "No dia 6 Deus criou os animais e as pessoas."
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#7ebf42"}}}
+Descoberta
+
+Cubra o fundo de uma caixa plástica rasa com areia moldável (8 xícaras de farinha misturada com 1 xícara de óleo vegetal) ou massa de modelar. Adicione conchas e recipientes e deixe seu filho tentar moldar uma pessoa. Converse sobre o quão incrível Deus é ao nos fazer todos únicos e especiais. Até mesmo nossas impressões digitais são diferentes!
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#7ebf42"}}}
+Ajude
+
+Proporcione oportunidades para seu filho ajudar ao seu lado ao guardar pratos, limpar a mesa, alimentar animais de estimação, ou fazer a lavanderia. Enquanto trabalham juntos, converse sobre o que estão fazendo e por quê. Compartilhe como as famílias se ajudam porque se amam, assim como Deus fez Adão e Eva para se ajudarem.
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#7ebf42"}}}
+Conecte
+
+Construa uma árvore genealógica com fotos de pessoas em sua família extensa, fixadas em círculos de papel verde feitos para parecer folhas em uma árvore. Recorte um tronco de árvore e galhos de papel marrom. Enquanto seu filho anexa as fotos à árvore, compartilhe sobre cada pessoa: nome, parentesco, onde vivem, características, etc. Quando concluído, agradeça a Deus por sua família especial.
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#7ebf42"}}}
+Ore
+
+Modele conversar com Deus sobre seu dia em oração. Nos momentos de oração, pergunte ao seu filho o que eles querem contar a Deus — nada é grande demais ou pequeno demais. Ore por membros específicos da família e agradeça a Deus pela família maravilhosa que Ele lhe deu.
+
+{"style": {"text": {"color": "#7ebf42", "typeface": "Omnes-Regular"}}
+**Versículo para memorizar semanal**: "Assim Deus criou o homem à sua própria imagem" (Gênesis 1:27).

--- a/src/pt/aij/2026-01-bg/11/03-the-heart-of-the-matter.md
+++ b/src/pt/aij/2026-01-bg/11/03-the-heart-of-the-matter.md
@@ -1,0 +1,28 @@
+---
+title: O Coração da Questão
+markdownTitle: 'o ^[CORAÇÃO]({"style": {"text": {"color": "#F38236"}}}) da ^[QUESTÃO]({"style": {"text": {"color": "#009955"}}})'
+subtitle: Para Pais
+markdownSubtitle: Para você, Pais
+style:
+  segment:
+    title:
+      text:
+        typeface: BaskervilleBT-Roman
+        align: center
+    subtitle:
+      text:
+        typeface: BaskervilleBT-Roman
+        align: center
+background: https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/11-04.png
+---
+
+Ao percorrer os corredores da seção de brinquedos da loja ou olhar através de página após página de brinquedos online disponíveis para comprar para o aniversário de seu filho, as escolhas parecem infinitas. Você cuida e leva tempo para decidir exatamente o que eles possam mais gostar. O que ajudará a aprender e desenvolver novas habilidades, com o que eles serão atraídos para brincar, e o que manterá sua atenção pelo maior tempo possível? Você imagina exatamente qual será o presente perfeito para eles.
+
+O ato culminante dos seis dias de Criação de Deus agora estava feito. Deus tinha criado Adão e Eva. Ele estava tão animado para mostrar-lhes o presente que tinha feito para eles: um belo jardim! O presente perfeito para Seus filhos em seu aniversário. Imagine a primeira caminhada que fizeram juntos. O quão divertido Deus teria tido, mostrando-lhes o que tinha feito para eles! Cada pequeno detalhe que Ele colocou em cada design de flor, cada tom de cor, cada animal grande e pequeno, o cheiro do ar do mar, as canções dos pássaros, tudo isso era para eles. "Tudo o que Deus tinha feito era a perfeição da beleza, e nada parecia faltar que pudesse contribuir para a felicidade do par santo. . . . Eles estariam constantemente ganhando novos tesouros de conhecimento, descobrindo novas fontes de felicidade, e obtendo concepções cada vez mais claras do amor imensurável e infalível de Deus" (Ellen G. White, ^[Patriarcas e Profetas]({"style": {"text": {"typeface": "Omnes-Italic"}}}), pp. 46-51).
+
+Há uma sensação de satisfação encontrada ao assistir seu filho abrir o presente que você escolheu cuidadosamente para eles enquanto batem palmas de empolgação e começam a explorar como brincar com ele. O mais simples dos presentes pode trazer alegria às crianças. Compartilhar seu novo presente com você e mostrar a você o que descobriram que podem fazer aumenta sua felicidade.
+
+Deus continua a se deliciar em dar bons presentes a Seus filhos. Imagine Sua alegria ao pintar um pôr do sol apenas para você ou inspirar um amigo a ligar ou providenciar dinheiro para chegar de uma fonte inesperada quando você mais precisa. Todo bom e perfeito presente vem de Deus. Ele anseia nos trazer felicidade e compartilhar esses momentos conosco. Tire o tempo hoje para pausar e pensar sobre os presentes que Deus lhe deu. Reconheça a alegria que Ele sente ao compartilhar o que você descobriu com Ele como o mesmo senso de prazer que você sente quando seu próprio filho aprecia os presentes que você dá.
+
+> <callout>Tiago 1:17, 18, NVI</callout>
+> "Toda boa dádiva e todo dom perfeito vêm do alto, descendo do Pai das luzes, que não muda como sombras inconstantes. Por sua decisão ele nos gerou por meio da palavra da verdade, a fim de sermos como que os primeiros frutos de tudo o que ele criou"

--- a/src/pt/aij/2026-01-bg/11/info.yml
+++ b/src/pt/aij/2026-01-bg/11/info.yml
@@ -1,0 +1,4 @@
+title: Deus Fez Adão e Eva
+subtitle: Semana 11
+start_date: "08/03/2026"
+end_date: "14/03/2026"

--- a/src/pt/aij/2026-01-bg/12/01-story.md
+++ b/src/pt/aij/2026-01-bg/12/01-story.md
@@ -1,0 +1,33 @@
+---
+title: Deus Fez Você
+type: story
+audio:
+    src: https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-12.mp3
+---
+
+;;;
+^^^
+{"style":{"image":{"storyTextAlign": "top"}}}
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/12-00.png)
+{"style":{"text":{"color": "#ffffff", "typeface": "Omnes-Bold", "align": "center"}, "block":{"backgroundColor": "#329066ad"}}}
+Deus Fez\
+^[Você]({"style":{"text":{"color": "#fdd840", "typeface": "Omnes-BoldItalic"}}})
+^^^
+^^^
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/12-01.png)
+{"style":{"text":{"color": "#ffffff"}, "block":{"backgroundColor": "#329066ad"}}}
+No princípio, antes de haver corujas que "uhu" ou cacatuas tagarelas, havia Deus. Deus criou a terra para mim e para você. No dia 1 Ele fez a luz, e no dia 2 Ele fez o céu. No dia 3 a grama e as flores cresceram. No dia 4 Ele fez o sol, a lua e as estrelas, e no dia 5 Ele fez os peixes e os pássaros ganhar vida. No dia 6 Deus fez animais — coelhos e hipopótamos (conte cada dia com os dedos). Deus viu tudo isso, e era bom! Deus guardou o melhor para o fim. Quando a terra estava pronta, Ele fez um homem e uma mulher. Tudo isso foi há muito tempo, mas Deus sabia que um dia haveria você. Quando o tempo era perfeito, Ele fez você — você maravilhoso! (Abraçar a criança.) Você foi criado exatamente certo — incrível aos olhos Dele.
+^^^
+^^^
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/12-02.png)
+{"style":{"text":{"color": "#ffffff"}, "block":{"backgroundColor": "#329066ad"}}}
+Olhe no espelho. O que você vê? (Dê o espelho à criança.) Você vê seus olhos? (Conte 1 . . . 2.) Seus olhos são (cor) como os meus (ou os meus são ____). Deus fez você com cabelo (claro/escuro) e o meu é _____. Você pode mexer seu nariz? Onde estão seus ouvidos? Conte-os: 1 . . . 2. Você pode fazer sua boca parecer feliz . . . triste . . . engraçada? Deus fez você tão bonito quanto possível!Deus fez olhos para ver nuvens brancas fofas no céu. O que você vê? (Coloque a mão sobre os olhos enquanto olha ao redor.) Ele criou ouvidos para ouvir pássaros cantando nas árvores. Escute . . . o que você ouve? (Copo a mão sobre o ouvido.) Ele fez dedos para sentir a pelagem macia de um gatinho. O que você sente que é macio? (Peça à criança trazer algo macio, irregular, áspero, liso.) Ele criou bocas para provar morangos suculentos. O que você gosta de provar? Ele fez narizes para cheirar rosas doces. Cheire, cheire . . . o que você cheira com seu nariz?
+^^^
+^^^
+{"style":{"image":{"storyTextAlign": "top"}}}
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/12-03.png)
+{"style":{"block": {"backgroundColor": "#ffffffad"},"text":{"color": "#000000"}}}
+Cada um de nós é diferente, mas Deus nos ama do mesmo jeito. Se você tem 10 dedos do pé para mexer ou um riso feliz, pés para caminhar ou marchar ao ritmo, pernas que pulam como um sapo ou pulam para cima e para baixo, mãos que batem palmas ou uma voz para cantar, cada parte de você é especial de verdade. (Faça com a criança enquanto lê.) Deus deu a você exatamente o que você precisaria. Você é perfeitamente projetado para os planos maravilhosos que Ele tem em mente.\
+(Diga juntos) Obrigado, Deus, por fazer EU! Deus tinha terminado Sua criação. O que Ele faria no dia 7?
+^^^
+;;;

--- a/src/pt/aij/2026-01-bg/12/02-play.md
+++ b/src/pt/aij/2026-01-bg/12/02-play.md
@@ -1,0 +1,57 @@
+---
+title: Brinque Durante o Dia
+markdownTitle: '^[Brinque]({"style": {"text": {"color": "#ed9a23"}}}) durante o dia'
+cover: https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/12-05.png
+titleBelowCover: true
+style:
+  segment:
+    title:
+      text:
+        typeface: Omnes-BlackItalic
+        align: center
+        color: "#38af4a"
+---
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#38af4a"}}}
+Crie
+
+Faça o contorno do corpo em tamanho real do seu filho com giz na calçada lá fora ou em uma grande folha de papel embrulho. Converse sobre todas as características que Deus criou em seu filho. Adicione-as às suas imagens, incluindo cabelo, umbigo, dedos do pé e características faciais. Dê ao seu filho um grande abraço e diga: "Deus fez você tão especial!"
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#38af4a"}}}
+Explore
+
+Compartilhe como Deus fez você para se mover. Configure um percurso de obstáculos com itens para rastejar, pular e caminhar sobre, sob e através usando travesseiros, cobertores, mesas, cadeiras e animais de pelúcia. Agradeça a Deus pela maneira incrível que Ele fez nossos corpos para se moverem.
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#38af4a"}}}
+Aprenda
+
+Marque o crescimento do seu filho em uma parede ou gráfico de crescimento. Repita regularmente para observar o crescimento. Compartilhe com seu filho como Deus fez seus corpos crescerem através de comer comida saudável, dormir, brincar e beber muita água.
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#38af4a"}}}
+Descubra
+
+Compartilhe com seu filho os cinco sentidos e explique como eles nos ajudam a explorar o mundo que Deus nos deu.
+
+
+{"style": {"block": {"padding": {"start": "xl"}}}}
+^[Ouvir]({"style" : {"text": {"color": "#38af4a", "typeface": "Omnes-Bold"}}}): Faça um instrumento musical para tocar em adoração usando arroz e uma garrafa de água vazia. Obrigado, Deus, por ouvidos para ouvir!
+
+{"style": {"block": {"padding": {"start": "xl"}}}}
+^[Cheirar]({"style" : {"text": {"color": "#38af4a", "typeface": "Omnes-Bold"}}}): Faça alguns muffins ou biscoitos juntos na cozinha. Tire um momento para cheirá-los quando estão no forno. Obrigado, Deus, por um nariz para cheirar!
+
+{"style": {"block": {"padding": {"start": "xl"}}}}
+^[Ver]({"style" : {"text": {"color": "#38af4a", "typeface": "Omnes-Bold"}}}): Cubra o fundo de uma panela rasa com leite rico em gordura. Pontilhe com corante alimentar. Mergulhe um cotonete em detergente, depois toque um ponto de cor. Observe enquanto a cor gira. Obrigado, Deus, por olhos para ver!
+
+{"style": {"block": {"padding": {"start": "xl"}}}}
+^[Sentir]({"style" : {"text": {"color": "#38af4a", "typeface": "Omnes-Bold"}}}): Procure alguns itens de fora para colocar em uma sacola de sentir para seu filho. Faça-os fechar os olhos e puxar um objeto. Peça-lhes para adivinhar o que é antes de abrir os olhos. Obrigado, Deus, por mãos para sentir!
+
+{"style": {"block": {"padding": {"start": "xl"}}}}
+^[Provar]({"style" : {"text": {"color": "#38af4a", "typeface": "Omnes-Bold"}}}): Faça um prato de degustação com muitas coisas diferentes para provar. Faça seu filho fechar os olhos e adivinhar o que está comendo. Converse sobre os diferentes sabores: doce, azedo, salgado. Obrigado, Deus, que posso provar as boas coisas que Você fez!
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#38af4a"}}}
+Cante e Ore
+
+Cante louvores a Deus com seu filho durante o dia. Ore e diga: "Obrigado, Deus, por me fazer para . . ."
+
+{"style": {"text": {"color": "#38af4a", "typeface": "Omnes-Regular"}}
+**Versículo para memorizar semanal**: "Eu Te louvarei, pois sou . . . maravilhosamente feito" (Salmos 139:14).

--- a/src/pt/aij/2026-01-bg/12/03-the-heart-of-the-matter.md
+++ b/src/pt/aij/2026-01-bg/12/03-the-heart-of-the-matter.md
@@ -1,0 +1,28 @@
+---
+title: O Coração da Questão
+markdownTitle: 'o ^[CORAÇÃO]({"style": {"text": {"color": "#237FC0"}}}) da ^[QUESTÃO]({"style": {"text": {"color": "#008750"}}})'
+subtitle: Para Pais
+markdownSubtitle: Para você, Pais
+style:
+  segment:
+    title:
+      text:
+        typeface: BaskervilleBT-Roman
+        align: center
+    subtitle:
+      text:
+        typeface: BaskervilleBT-Roman
+        align: center
+background: https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/12-04.png
+---
+
+Deus criou cada criança à Sua imagem, exclusivamente projetada para refletir Sua glória. Seu filho é precioso e é tesouro de Deus. Ensinar seu filho que sua identidade é encontrada em Cristo exigirá esforço intencional para falar Sua verdade em suas vidas.
+
+O mundo está pronto e esperando para enviar mensagens conflitantes e prejudiciais ao seu filho enquanto cresce. O mundo dirá: "Ame a si mesmo." "Você tem o poder dentro de você para ser qualquer coisa que você quiser ser." O mundo também envia mensagens de que, a menos que você pareça, aja ou consuma certas coisas, você não é bonito o suficiente, inteligente o suficiente ou talentoso o suficiente. Ambos os conjuntos de mensagens são perigosos. Para ser protegido dessas mensagens prejudiciais, seu filho precisará saber que sua identidade está apenas em Cristo. Não está no que faz ou em quantos adesivos ganha; nem está em seu mau comportamento ou em seus erros.
+
+Seu filho não apenas anseia por seu tempo, atenção e aprovação, mas é projetado para precisar disso. Se não receber isso de você, procurará em outro lugar. É através da interação positiva com os adultos em suas vidas que eles aprendem o que é social e comportamentalmente apropriado, que ganham confiança para explorar e experimentar coisas novas, e que percebem o que o amor incondicional parece e parece ser. Quando isso é emparelhado com a verdade da Palavra de Deus e Seu amor incondicional, eles podem então descobrir quem Ele os fez ser e sua verdadeira identidade como filho de Deus.
+
+A luz que você brilha na vida do seu filho refletirá sua própria aceitação do amor incondicional de Deus por você. Como pai ou guardião, você também será bombardeado com mensagens que tentarão convencê-lo de que você não é bom o suficiente. Abraçe o amor incondicional de Deus em sua própria vida. Romanos 8 nos diz que nada pode nos separar do amor de Deus. Tenha confiança em Deus e confie em Sua promessa de que Ele projetou você à Sua imagem para revelar Sua glória, pois verdadeiramente, "o preço pago pela nossa redenção, o sacrifício infinito de nosso Pai celestial em dar Seu Filho para morrer por nós, deve nos dar concepções exaltadas do que podemos nos tornar através de Cristo" (Ellen G. White, ^[Caminho a Cristo]({"style": {"text": {"typeface": "Omnes-Italic"}}}), p. 15).
+
+> <callout>2 Coríntios 4:6, NVI</callout>
+> "Pois Deus, que disse: 'Das trevas resplandeça a luz', fez brilhar a sua luz em nossos corações, para iluminação do conhecimento da glória de Deus na face de Cristo"

--- a/src/pt/aij/2026-01-bg/12/info.yml
+++ b/src/pt/aij/2026-01-bg/12/info.yml
@@ -1,0 +1,4 @@
+title: Deus Fez Você
+subtitle: Semana 12
+start_date: "15/03/2026"
+end_date: "21/03/2026"

--- a/src/pt/aij/2026-01-bg/13/01-story.md
+++ b/src/pt/aij/2026-01-bg/13/01-story.md
@@ -1,0 +1,39 @@
+---
+title: Deus Fez o Sábado
+type: story
+audio:
+    src: https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/ABSG-2025-01-BG-13.mp3
+---
+
+;;;
+^^^
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/13-00.png)
+{"style":{"text":{"color": "#ffffff", "typeface": "Omnes-Bold", "align": "center"}, "block":{"backgroundColor": "#7d4d3878"}}}
+Deus Fez o\
+^[Sábado]({"style":{"text":{"color": "#ffd800", "typeface": "Omnes-BoldItalic"}}})
+^^^
+^^^
+{"style":{"image":{"storyTextAlign": "top"}}}
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/13-01.png)
+{"style":{"text":{"color": "#ffffff"}, "block":{"backgroundColor": "#329066ad"}}}
+No princípio, antes de haver pandas preto e branco ou melancias doces, havia Deus. A semana estava chegando ao fim, enquanto o dia 7 (sete dedos) estava pronto para começar. Em seis (seis dedos) dias Deus criou a terra, o céu e tudo neles. Ele tinha feito o sol e a lua, ervilhas doces e bambu alto. Havia guepardos super rápidos e macacos comendo bananas; pássaros azuis nas árvores, e baleias nos mares. Agora Deus queria estar com Adão e Eva.
+^^^
+^^^
+{"style":{"image":{"storyTextAlign": "top"}}}
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/13-02.png)
+{"style":{"text":{"color": "#ffffff"}, "block":{"backgroundColor": "#329066ad"}}}
+Adão e Eva ficaram no jardim e observaram o sol se pôr baixo. Laranja brilhante e rosa iluminaram o céu com um brilho. O dia 7 começou quando as estrelas saíram uma a uma. Um par de corujas chamou "Huu", enquanto um sapo coaxou "Ribbit" no lago. Duas girafas mastigaram folhas ao luar. Toda a criação de Deus estava pronta para descansar. O que Deus faria a seguir?
+^^^
+^^^
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/13-03.png)
+{"style":{"text":{"color": "#ffffff"}, "block":{"backgroundColor": "#329066ad"}}}
+Este dia era o mais especial de todos. Este dia era como um presente e seria diferente de todos os outros. Deus declarou que o sétimo dia seria um dia de descanso, um que seria abençoado. Deus fez este dia para mostrar Seu grande amor para que nossas mentes pudessem se voltar a Ele acima de tudo. O Sábado é um tempo especial para passar louvando-O; uma maneira de dizer "Obrigado" (mãos juntas) por tudo o que Ele tem dado. Era o primeiro Sábado de Adão e Eva em seu belo lar no Éden. Eles comeram café da manhã sob uma árvore carregada de mangas ou sentaram-se à beira do rio observando flamingos? Eles caminharam ao longo de um caminho com Deus, maravilhados com o rugido do leão e o quão alto a águia pode voar (mão voando alto como um pássaro). Eles O agradeceram pelas uvas suculentas e riram juntos com os macacos engraçados. Deus também ensinou a Adão e Eva muitas coisas importantes sobre seu mundo e como confiar e obedecer a Ele. Quando o sol se punha baixo, o Sábado logo terminaria. Adão e Eva sabiam que eram abençoados, e agradeceram a Deus por um dia maravilhoso de descanso.
+^^^
+^^^
+{"style":{"image":{"storyTextAlign": "top"}}}
+![](https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/13-04.png)
+{"style":{"block": {"backgroundColor": "#ffffffad"},"text":{"color": "#000000"}}}
+Um, dois, três, quatro, cinco, seis (conte com os dedos) dias de Criação. Então sete, o melhor de todos! Um dia de Sábado de descanso. Um dia especial para aprender sobre Deus e Seu amor. Tempo para passar com família e amigos, e tempo para dizer "Obrigado" a Deus acima. Um dia para explorar grandes montanhas ou belos prados, para cantar canções na igreja e compartilhar um almoço delicioso. O que você gosta mais neste dia tão santo e abençoado?\
+(Diga juntos) Obrigado, Deus, pelo Sábado!
+^^^
+;;;

--- a/src/pt/aij/2026-01-bg/13/02-play.md
+++ b/src/pt/aij/2026-01-bg/13/02-play.md
@@ -1,0 +1,41 @@
+---
+title: Brinque Durante o Dia
+markdownTitle: '^[Brinque]({"style": {"text": {"color": "#a48da5"}}}) durante o dia'
+cover: https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/13-05.png
+titleBelowCover: true
+style:
+  segment:
+    title:
+      text:
+        typeface: Omnes-BlackItalic
+        align: center
+        color: "#9e5f94"
+---
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#9e5f94"}}}
+Crie
+
+Ajude seu filho a fazer a última página do Livro da Criação para representar o dia 7. Use lápis e marcadores para decorar a página com desenhos de coisas que vocês gostam de fazer juntos no Sábado. Escreva: "No dia 7 Deus descansou. Obrigado, Deus, pelo Sábado!" Quando terminar, faça sete buracos ao longo da borda esquerda de cada página da semana. Passe e amarre corda pelos buracos para unir o livro. Leia o livro da Criação frequentemente para lembrar seu filho sobre a incrível criação de Deus.
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#9e5f94"}}}
+Explore
+
+Vá em uma aventura na natureza. Pode ser o quintal, as matas, uma praia ou um parque. Faça o almoço de Sábado ao ar livre. Converse sobre algumas de suas coisas favoritas na criação. Agradeça a Deus por elas. Leve um diário de natureza em branco e alguns lápis para desenhar algumas das coisas incríveis que você encontra na natureza de Deus.
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#9e5f94"}}}
+Faça
+
+Crie uma sacola com brinquedos pequenos e silenciosos e livros de Sábado que são especiais para a igreja. Você pode incluir adesivos de natureza, quebra-cabeças de animais, animais de plástico, livros especiais de Sábado e lápis de cor. Você também pode criar uma caixa ou cesta de brinquedos que são especiais apenas para o Sábado, para uso quando você está em casa. Tire-os todo Sábado para que permaneçam especiais e empolgantes.
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#9e5f94"}}}
+Estabeleça
+
+Estabeleça algumas tradições familiares que tornem a sexta-feira à noite especial. Por exemplo: jantar à luz de velas, buquê de flores, comida específica de sexta-feira à noite, uma canção ao pôr do sol, ou um novo livro de imagens bíblico. Pense em algo facilmente acessível em sua cultura que possa tornar a sexta-feira à noite especial além de ler a Bíblia.
+
+{"style": {"text": {"typeface": "Omnes-BlackItalic", "size": "lg", "color": "#9e5f94"}}}
+Ore
+
+Durante o culto na sexta-feira à noite, passe algum tempo cantando e louvando a Deus. Peça a cada pessoa para compartilhar as bênçãos da semana. Anote-as em um diário familiar que você usa toda sexta-feira à noite. Compartilhe o que você está mais animado sobre o Sábado amanhã. Agradeça a Deus pelo descanso que o Sábado nos dá, e peça-Lhe para abençoar o tempo que vocês compartilham juntos amanhã.
+
+{"style": {"text": {"color": "#9e5f94", "typeface": "Omnes-Regular"}}
+**Versículo para memorizar semanal**: "Deus abençoou o sétimo dia" (Gênesis 2:3).

--- a/src/pt/aij/2026-01-bg/13/03-the-heart-of-the-matter.md
+++ b/src/pt/aij/2026-01-bg/13/03-the-heart-of-the-matter.md
@@ -1,0 +1,32 @@
+---
+title: O Coração da Questão
+markdownTitle: 'o ^[CORAÇÃO]({"style": {"text": {"color": "#EC3338"}}}) da ^[QUESTÃO]({"style": {"text": {"color": "#007C4C"}}})'
+subtitle: Para Pais
+markdownSubtitle: Para você, Pais
+style:
+  segment:
+    title:
+      text:
+        typeface: BaskervilleBT-Roman
+        align: center
+    subtitle:
+      text:
+        typeface: BaskervilleBT-Roman
+        align: center
+background: https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/13/hm-background.png
+---
+
+Imagine como foi aquele primeiro Sábado para Adão e Eva! Sua empolgação e maravilha em estar com Deus em Seu jardim teriam sido expressas através de louvor a seu Criador. Teria sido um dia cheio de descoberta enquanto passavam tempo juntos e aprendiam mais sobre Deus, uns aos outros e tudo o que Ele tinha feito.
+
+Como é o Sábado em sua casa, como soa e como parece? Às vezes podemos estar tão ocupados conduzindo ao Sábado que é difícil sair do ciclo de centrifugação da vida. Contudo Deus nos chama a pausar, a "ficar quietos", a tomar um tempo extra especial com Ele e com nossa família e com outros crentes. Ele sabe que precisamos disso.
+
+Pense sobre como você pode simples e significativamente nutrir o amor por Deus e Seu dia especial e abençoado com seus filhos.
+
+Considere as necessidades do seu filho e forneça expectativas positivas que ajudarão a aprender que a igreja é um lugar reverente de louvor e adoração; um lugar onde você gosta de ir. Modele para eles o que significa se deliciar no Sábado.
+
+Em Sua sabedoria infinita Deus sabia que precisaríamos fazer uma pausa de nossas semanas ocupadas. Ore sobre como você pode cuidadosa e intencionalmente passar este tempo com Deus e sua família, sabendo que Deus vê todas as suas necessidades — sua vida ocupada, seu cansaço, sua necessidade de alimento espiritual, e seu desejo inato de conexão com outros e, ultimately, com Ele.
+
+"Deus viu que um Sábado era essencial para o homem, mesmo no Paraíso. Ele precisava deixar de lado seus próprios interesses e perseguições por um dia dos sete, para que pudesse contemplar mais plenamente as obras de Deus e meditar sobre Seu poder e bondade. Ele precisava de um Sábado para lembrá-lo mais vividamente de Deus e para despertar gratidão porque tudo o que ele desfrutava e possuía vinha da mão benfazeja do Criador" (Ellen G. White, ^[Patriarcas e Profetas]({"style": {"text": {"typeface": "Omnes-Italic"}}}), p. 48).
+
+> <callout>Salmos 100:2, NVI</callout>
+> "Sirvam ao Senhor com alegria e entrem na sua presença com cânticos"

--- a/src/pt/aij/2026-01-bg/13/info.yml
+++ b/src/pt/aij/2026-01-bg/13/info.yml
@@ -1,0 +1,4 @@
+title: Deus Fez o Sábado
+subtitle: Semana 13
+start_date: "22/03/2026"
+end_date: "28/03/2026"

--- a/src/pt/aij/2026-01-bg/info.yml
+++ b/src/pt/aij/2026-01-bg/info.yml
@@ -1,0 +1,87 @@
+title: 'Vivos em Jesus: Criação'
+subtitle: Ano A, Trimestre 1
+description: Deus criou nosso maravilhoso mundo em sete dias.
+primaryColor: '#39788D'
+primaryColorDark: '#1F5A6D'
+credits:
+  - name: Contribuidora Principal
+    value: Linda Schaffner
+  - name: Gerente de Currículo e Editora Sênior
+    value: Nina Atcheson
+  - name: Editora
+    value: Rosanne Peach
+  - name: Assistente Editorial
+    value: Denise Gustafson
+  - name: Diretor Mundial da Escola Sabatina
+    value: Daniel Ebenezer
+  - name: Conselheiro do Instituto de Pesquisa Bíblica
+    value: Clinton Wahlen
+  - name: Diretora de Criação
+    value: Meredith Herzel
+  - name: Ilustradora
+    value: Hannah Justinen
+  - name: Designer
+    value: Types & Symbols
+  - name: Editores de Texto
+    value: James and Ida Cavil
+displaySequence: true
+style:
+  blocks:
+    inline:
+      all:
+        text:
+          typeface: Omnes-Regular
+    nested:
+      all:
+        text:
+          typeface: Omnes-Regular
+  resource:
+    title:
+      text:
+        typeface: Omnes-Bold
+    subtitle:
+      text:
+        typeface: Omnes-Regular
+fonts:
+  - name: BaskervilleBT-Roman
+    weight: 400
+    src: >-
+      https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/fonts/BaskervilleBT-Roman.ttf
+    attributes: regular
+  - name: Omnes-BlackItalic
+    weight: 900
+    src: >-
+      https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/fonts/Omnes%20Black%20Italic.ttf
+    attributes: black-italic
+  - name: Omnes-Black
+    weight: 900
+    src: >-
+      https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/fonts/Omnes%20Black.ttf
+    attributes: black
+  - name: Omnes-BoldItalic
+    weight: 700
+    src: >-
+      https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/fonts/Omnes%20Bold%20Italic.ttf
+    attributes: bold-italic
+  - name: Omnes-Bold
+    weight: 700
+    src: >-
+      https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/fonts/Omnes%20Bold.ttf
+    attributes: bold
+  - name: Omnes-Italic
+    weight: 400
+    src: >-
+      https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/fonts/Omnes%20Italic.ttf
+    attributes: regular-italic
+  - name: Omnes-Regular
+    weight: 400
+    src: >-
+      https://sabbath-school-resources-assets.adventech.io/en/aij/2025-01-bg/assets/fonts/Omnes%20Regular.ttf
+    attributes: regular
+covers:
+  landscape: >-
+    https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-bg/assets/cover-landscape.png
+  square: >-
+    https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-bg/assets/cover-square.png
+  portrait: >-
+    https://sabbath-school-resources-assets.adventech.io/en/aij/2026-01-bg/assets/cover.png

--- a/src/pt/aij/2026-01-bg/introduction.md
+++ b/src/pt/aij/2026-01-bg/introduction.md
@@ -1,0 +1,3 @@
+### Criação
+
+Deus criou nosso maravilhoso mundo em sete dias.

--- a/src/pt/aij/feed.yml
+++ b/src/pt/aij/feed.yml
@@ -1,0 +1,7 @@
+---
+  title: Vivos em Jesus
+  groups:
+  - group: Iniciante
+    view: folio
+    resources:
+      - pt-aij-2026-01-bg

--- a/src/pt/info.yml
+++ b/src/pt/info.yml
@@ -1,8 +1,9 @@
-name: Portugese
+name: Portuguese
 native: Português
 code: pt
 sections:
   default: Main
+egw: true
 bible:
   - arc
   - nvi-pt


### PR DESCRIPTION
## What This PR Adds

Portuguese (pt-BR) translation of **Alive in Jesus (AIJ) Beginner** curriculum for Q1 2026 (Year A, Quarter 1) — **all 13 weeks complete**.

This is the **first AIJ age group translated to Portuguese**, making pt-BR the **second language worldwide** with AIJ content (English was first).

---

## Structure

### Weekly Lessons (13 complete weeks)
Each week contains 3 markdown files plus an `info.yml`:

| File | Content |
|------|---------|
| `01-story.md` | The Bible story |
| `02-play.md` | Activities and play ideas |
| `03-the-heart-of-the-matter.md` | Spiritual lesson / devotional thought |

| Week | Title (PT-BR) | Date Range |
|------|---------------|------------|
| 01 | No Princípio | Dec 28 – Jan 03 |
| 02 | Deus Fez a Luz | Jan 04 – Jan 10 |
| 03 | Deus Fez o Céu | Jan 11 – Jan 17 |
| 04 | Deus Fez a Terra Seca | Jan 18 – Jan 24 |
| 05 | Deus Fez as Plantas | Jan 25 – Jan 31 |
| 06 | Deus Fez o Sol, a Lua e as Estrelas | Feb 01 – Feb 07 |
| 07 | Deus Fez a Terra | Feb 08 – Feb 14 |
| 08 | Deus Fez os Peixes do Mar | Feb 15 – Feb 21 |
| 09 | Deus Fez as Aves do Céu | Feb 22 – Feb 28 |
| 10 | Deus Fez os Animais | Mar 01 – Mar 07 |
| 11 | Deus Fez Adão e Eva | Mar 08 – Mar 14 |
| 12 | Deus Fez Você | Mar 15 – Mar 21 |
| 13 | Deus Fez o Sábado | Mar 22 – Mar 28 |

### Special Sections (3 sections)
- `00-introduction/` — Introduction for parents
- `00-little-devotions/` — Short devotional readings
- `00-music-and-podcasts/` — Music and podcast references

### Top-Level Files
- `info.yml` — Quarterly metadata (title, description, colors, fonts, covers, credits)
- `introduction.md` — Quarterly introduction
- `feed.yml` — AIJ PT-BR feed registration (new file)
- `src/pt/info.yml` — Added `egw: true` flag (required to render EGW references) + typo fix

---

## File Count

| Component | Files |
|-----------|-------|
| Weekly (13 weeks × 4 files) | 52 |
| Special sections | 6 |
| Top-level | 2 |
| `feed.yml` | 1 |
| `src/pt/info.yml` (modified) | 1 |
| **Total** | **62 files** |

---

## Source

Translated from English source files in `src/en/aij/2026-01-bg/`.

The Beginner age group uses a simpler 3-file structure (story/play/heart) compared to Kindergarten and Primary (which use 7 daily files).

---

## Other Changes

- **`src/pt/aij/feed.yml`** (new): Registers the AIJ quarterly type for Portuguese, enabling discovery via the API
- **`src/pt/info.yml`** (modified):
  - Added `egw: true` — required for the rendering pipeline to parse Ellen G. White references in AIJ content
  - Fixed typo in existing field

---

## Known Limitations

- **Cover assets**: Still point to English CDN (`sabbath-school-resources-assets.adventech.io/en/aij/2026-01-bg/...`). PT-BR cover assets will be needed once available from CPB.

---

## Related PRs

- **#64**: AIJ Kindergarten + Primary Q1 2026 (PT-BR) — 7 weeks each (in progress)

---

## Context

The AIJ curriculum ("Vivos em Jesus" in Portuguese) is the new Sabbath School curriculum for children (Beginner: birth–2 years), published by the General Conference. Brazil has one of the largest Adventist populations globally (~1.8 million members), making Portuguese a high-priority language for AIJ translation.